### PR TITLE
OpenSource the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.*.sw[op]
+*~
+/.idea/
+/vendor/
+/composer.lock
+composer.phar

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Elan Ruusamäe <glen@pld-linux.org>
+Lauri Piisang <lauri.piisang@eesti.ee>

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2017 Lauri Piisang
 Copyright (c) 2019 Elan Ruusamäe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,119 @@
 # PHP Profiler
 
-A PHP profiling library based on XHGUI Data Collector.
+A PHP profiling library based on [XHGUI Data Collector][1].
+
+Supported profilers:
+ - XHProf - PHP >= 5.3, < PHP 7.0
+ - Tideways - PHP >= 7.0
+ - UProfiler - PHP >= 5.3, < PHP 7.0
+
+[XHProf]: https://pecl.php.net/package/xhprof
+[Tideways]: https://github.com/tideways/php-xhprof-extension
+[UProfiler]: https://github.com/FriendsOfPHP/uprofiler
+
+This profiling library will auto-detect what you have installed and use that.
+
+The preference order is currently as follows:
+1. uprofiler
+1. tideways
+1. xhprof
+
+DON'T RELY ON THIS PREFERENCE ORDER IN PRODUCTION ENVIRONMENTS.
+
+You shouldn't have more than one profiler installed in production.
+
+## Installing profilers
+
+### Mongo
+
+For PHP 5:
+```
+pecl install mongo
+```
+
+for PHP 7:
+```
+pecl install mongodb
+composer require alcaeus/mongo-php-adapter
+```
+
+### XHProf
+
+```
+pecl install xhprof-beta
+```
+
+### Tideways
+
+```
+curl -sSfL https://github.com/tideways/php-xhprof-extension/archive/v4.1.6.tar.gz | tar zx
+cd php-xhprof-extension-4.1.6/
+phpize
+./configure
+make
+make install
+echo extension=/usr/local/lib/php/pecl/20160303/tideways.so | tee /usr/local/etc/php/7.1/conf.d/ext-tideways.ini
+```
+
+## Usage
+
+In order to profile your application, add it as a dependency, then
+configure it and choose a place to start profiling from.
+
+Most likely you'll have something like
+
+```php
+<?php
+// inside some bootstrapper or other "early central point in execution"
+try {
+	/**
+	 * The constructor will throw an exception if the environment
+	 * isn't fit for profiling (extensions missing, other problems)
+	 */
+	$profiler = new \Xhgui\Profiler\Profiler($profilerConfig);
+
+	// The profiler itself checks whether it should be enabled
+	// for request (executes lambda function from config)
+	$profiler->enable();
+
+	// shutdown handler collects and stores the data.
+	$profiler->registerShutdownHandler();
+} catch (Exception $e){
+	// throw away or log error about profiling instantiation failure
+}
+```
+
+## Configuration
+
+Most of the configuration is xhgui standard and used by Xhgui saver.
+See [XHGUI Data Collector packagist page][1] for references.
+
+Configuration unique to this package:
+
+| Configuration option | type  | description                                      | default value |
+|----------------------|-------|--------------------------------------------------|---------------|
+| profiler.flags       | array | Array of [ProfilingFlags][2]                     | empty array   |
+| profiler.options     | array | Array of options to pass to profiler enable call | empty array   |
+
+What you'll likely need to configure when instructing an app to use this profiling:
+
+ - save handler type
+ - save handler properties (for mongodb, the access credentials, host, db)
+ - profiler.flags -- whether to use CPU profiling, memory profiling
+ - profiler.enable -- closure which determines whether profiling should run
+
+## Run description
+
+When Profiler object constructed, it determines that requirements are in place, whether
+profiling should run, which save handler to construct and constructs the save handler.
+In case of failures, it will throw an exception.
+
+`enable` will detect an available profiler and call its enable function with the current
+configuration.
+
+`registerShutdownHandler` will ensure profer is running and then call
+`register_shutdown_handler`. It will register a shutdown handler that provides the
+calls for finishing profiling and storing the data.
+
+[1]: https://packagist.org/packages/perftools/xhgui-collector
+[2]: src/ProfilingFlags.php

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+	"name": "perftools/php-profiler",
+	"description": "PHP Profiling based on XHGUI",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Lauri Piisang",
+			"email": "lauri.piisang@eesti.ee"
+		},
+		{
+			"name": "Elan Ruusamäe",
+			"email": "glen@pld-linux.org"
+		}
+	],
+	"config": {
+		"sort-packages": true
+	},
+	"autoload": {
+		"psr-4": {
+			"Xhgui\\Profiler\\": "src/"
+		}
+	},
+	"require": {
+		"php": "^5.3.0 || ^7.0",
+		"perftools/xhgui-collector": "^1.1.0"
+	},
+	"suggest": {
+		"ext-mongo": "mongo extension (PHP>=5.3,<7.0)",
+		"ext-mongodb": "mongodb extension (PHP>=5.4,<7.3)",
+		"alcaeus/mongo-php-adapter": "Adapter to provide ext-mongo interface on top of mongo-php-libary"
+	}
+}

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace Xhgui\Profiler;
+
+use Exception;
+use MongoClient;
+use MongoCollection;
+use MongoCursorException;
+use MongoCursorTimeoutException;
+use MongoDate;
+use MongoException;
+use RuntimeException;
+use Xhgui\Profiler\Profilers\AbstractProfiler;
+use Xhgui_Config;
+use Xhgui_Saver;
+use Xhgui_Saver_Interface;
+use Xhgui_Saver_Mongo;
+use Xhgui_Util;
+
+class Profiler
+{
+    /**
+     * Profiler configuration.
+     *
+     * @var array
+     * @see Xhgui_Config
+     * @see https://raw.githubusercontent.com/perftools/xhgui/6dac03aaa37df4b42d949bf4f8455573bea44e03/config/config.default.php
+     */
+    protected $config;
+
+    const PROFILER_XHPROF = 'xhprof';
+    const PROFILER_TIDEWAYS = 'tideways';
+    const PROFILER_UPROFILER = 'uprofiler';
+
+    /**
+     * @var Xhgui_Saver_Interface
+     */
+    protected $saveHandler;
+
+    /**
+     * @var AbstractProfiler
+     */
+    protected $profiler;
+
+    /**
+     * Result of config `profiler.enable` function execution.
+     *
+     * @var bool
+     */
+    protected $shouldRun;
+
+    /**
+     * Simple state variable to hold the value of 'Is the profiler running or not?'
+     *
+     * @var bool
+     */
+    protected $running;
+
+    /**
+     * Profiler constructor.
+     *
+     * @param array $config
+     * @throws RuntimeException if unable to create profiler
+     */
+    public function __construct(array $config)
+    {
+        $this->config = array_replace($this->getDefaultConfig(), $config);
+        $shouldRunFunction = $this->config['profiler.enable'];
+        $this->shouldRun = is_callable($shouldRunFunction) ? $shouldRunFunction() : false;
+        if (!$this->validateExtensionsInstalled()) {
+            throw new RuntimeException('Unable to create profiler: cannot find extensions');
+        }
+        if (!$this->canSave()) {
+            throw new RuntimeException('Unable to create profiler: unable to save data');
+        }
+        $this->saveHandler = Xhgui_Saver::factory($this->config);
+    }
+
+    /**
+     * Enables profiling for the current request / CLI execution
+     */
+    public function enable()
+    {
+        $this->running = false;
+        if (!$this->shouldRun) {
+            return;
+        }
+
+        if (!isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+            $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
+        }
+
+        $profiler = ProfilerFactory::make($this->getProfilerType());
+        if (!($profiler instanceof AbstractProfiler)) {
+            return;
+        }
+
+        $profiler->enableWith($this->config['profiler.flags'], $this->config['profiler.options']);
+        $this->profiler = $profiler;
+        $this->running = true;
+    }
+
+    /**
+     * Calls register_shutdown_function .
+     * Registers this class' shutDown method as the shutdown handler
+     *
+     * @see Profiler::shutDown
+     */
+    public function registerShutdownHandler()
+    {
+        // do not register shutdown function if the profiler isn't running
+        if (!$this->running) {
+            return;
+        }
+
+        register_shutdown_function(array($this, 'shutDown'));
+    }
+
+    public function shutDown()
+    {
+        // ignore_user_abort(true) allows your PHP script to continue executing, even if the user has terminated their request.
+        // Further Reading: http://blog.preinheimer.com/index.php?/archives/248-When-does-a-user-abort.html
+        // flush() asks PHP to send any data remaining in the output buffers. This is normally done when the script completes, but
+        // since we're delaying that a bit by dealing with the xhprof stuff, we'll do it now to avoid making the user wait.
+        ignore_user_abort(true);
+        flush();
+
+        try {
+            $this->stop();
+        } catch (Exception $e) {
+            return;
+        }
+    }
+
+    /**
+     * Determines which profiler you're running.
+     * If you're running multiple (which you shouldn't!),
+     * It will return them in this preference order :
+     * 1) uprofiler
+     * 2) tideways
+     * 3) xhprof
+     *
+     * @return string|null
+     */
+    protected function getProfilerType()
+    {
+        $profiler = null;
+        $extensions = array(self::PROFILER_XHPROF, self::PROFILER_TIDEWAYS, self::PROFILER_UPROFILER);
+        foreach ($extensions as $extension) {
+            $profiler = extension_loaded($extension) ? $extension : $profiler;
+        }
+
+        return $profiler;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function validateExtensionsInstalled()
+    {
+        return $this->getProfilerType() && (extension_loaded('mongo') || extension_loaded('mongodb'));
+    }
+
+    /**
+     * Mostly copypasta from example header.php in XHGUI
+     *
+     * @param array $data
+     * @return array
+     */
+    protected function assembleProfilingData($data)
+    {
+        $uri = array_key_exists('REQUEST_URI', $_SERVER)
+            ? $_SERVER['REQUEST_URI']
+            : null;
+        if (empty($uri) && isset($_SERVER['argv'])) {
+            $cmd = basename($_SERVER['argv'][0]);
+            $uri = $cmd . ' ' . implode(' ', array_slice($_SERVER['argv'], 1));
+        }
+
+        $time = array_key_exists('REQUEST_TIME', $_SERVER)
+            ? $_SERVER['REQUEST_TIME']
+            : time();
+        $requestTimeFloat = explode('.', $_SERVER['REQUEST_TIME_FLOAT']);
+        if (!isset($requestTimeFloat[1])) {
+            $requestTimeFloat[1] = 0;
+        }
+
+        if ($this->saveHandler instanceof Xhgui_Saver_Mongo) {
+            $requestTs = new MongoDate($time);
+            $requestTsMicro = new MongoDate($requestTimeFloat[0], $requestTimeFloat[1]);
+        } else {
+            $requestTs = array('sec' => $time, 'usec' => 0);
+            $requestTsMicro = array('sec' => $requestTimeFloat[0], 'usec' => $requestTimeFloat[1]);
+        }
+
+        $allowedServerKeys = array(
+            'PHP_SELF',
+            'SERVER_ADDR',
+            'SERVER_NAME',
+            'REQUEST_METHOD',
+            'REQUEST_TIME',
+            'REQUEST_TIME_FLOAT',
+            'QUERY_STRING',
+            'DOCUMENT_ROOT',
+            'HTTP_HOST',
+            'HTTP_USER_AGENT',
+            'HTTPS',
+            'REMOTE_ADDR',
+            'REMOTE_USER',
+            'PHP_AUTH_USER',
+            'PATH_INFO',
+        );
+        $serverMeta = array_intersect_key($_SERVER, array_flip($allowedServerKeys));
+
+        $data['meta'] = array(
+            'url' => $uri,
+            'get' => $_GET,
+            'env' => $_ENV,
+            'SERVER' => $serverMeta,
+            'simple_url' => Xhgui_Util::simpleUrl($uri),
+            'request_ts' => $requestTs,
+            'request_ts_micro' => $requestTsMicro,
+            'request_date' => date('Y-m-d', $time),
+        );
+
+        return $data;
+    }
+
+    /**
+     * @return array
+     * @see Xhgui_Config
+     */
+    protected function getDefaultConfig()
+    {
+        $file = $this->getDefaultConfigFile();
+        if ($file) {
+            Xhgui_Config::load($file);
+        }
+
+        $defaultShouldRunFunction =
+            /**
+             * Determine whether profiler should run.
+             * This default implementation just disables the profiler.
+             * Override this with your custom logic in your config
+             * @return bool
+             */
+            function () {
+                return false;
+            };
+
+        return array_replace(Xhgui_Config::all(),
+            array(
+                'profiler.enable' => $defaultShouldRunFunction,
+                'profiler.flags' => array(),
+                'profiler.options' => array(),
+            )
+        );
+    }
+
+    private function getDefaultConfigFile()
+    {
+        $paths = array(
+            // aside the vendor
+            dirname(dirname(dirname(__DIR__))) . '/perftools/xhgui-collector/config/config.default.php',
+        );
+
+        foreach ($paths as $path) {
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function canSave()
+    {
+        $saveHandler = $this->config['save.handler'];
+        if ($saveHandler === 'file' && $this->canSaveToFile()) {
+            return true;
+        }
+
+        return $saveHandler === 'mongodb' && $this->canSaveToMongo();
+    }
+
+    /**
+     * @return bool
+     */
+    protected function canSaveToFile()
+    {
+        return is_writable(dirname($this->config['save.handler.filename']));
+    }
+
+    /**
+     * @return bool
+     */
+    protected function canSaveToMongo()
+    {
+        $config = $this->config;
+        try {
+            $mongoConnection = new MongoClient($config['db.host'], $config['db.options']);
+            $mongoConnection->connect();
+            $collection = $mongoConnection->selectCollection($config['db.db'], 'results');
+            if (!$collection instanceof MongoCollection) {
+                throw new Exception('failed getting collection');
+            }
+            $collection->findOne(array(), array('_id' => 1), array('maxTimeMS' => 300));
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * This is an alias for method "enable"
+     */
+    public function start()
+    {
+        $this->enable();
+    }
+
+    /**
+     * Stop profiling. Get currently collected data and save it
+     *
+     * @throws MongoException
+     * @throws MongoCursorException
+     * @throws MongoCursorTimeoutException
+     */
+    public function stop()
+    {
+        $data = $this->collectProfilingData();
+        $this->saveProfilingData($data);
+        $this->running = false;
+    }
+
+    /**
+     * Returns collected profiling data
+     *
+     * @return array
+     */
+    private function collectProfilingData()
+    {
+        if (!$this->running) {
+            return array();
+        }
+        $rawProfilingData = array('profile' => $this->profiler->disable());
+
+        return $this->assembleProfilingData($rawProfilingData);
+    }
+
+    /**
+     * Saves collected profiling data
+     *
+     * @param array $data
+     */
+    private function saveProfilingData(array $data = null)
+    {
+        if (!$data) {
+            return;
+        }
+
+        $this->saveHandler->save($data);
+    }
+
+    /**
+     * Tells, if profiler is running or not
+     *
+     * @return bool
+     */
+    public function isRunning()
+    {
+        return $this->running;
+    }
+}

--- a/src/ProfilerFactory.php
+++ b/src/ProfilerFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Xhgui\Profiler;
+
+final class ProfilerFactory
+{
+    /**
+     * @param string|null $profilerType
+     * @return Profilers\XHProf|Profilers\UProfiler|Profilers\Tideways|null
+     */
+    public static function make($profilerType)
+    {
+        switch ($profilerType) {
+            case Profiler::PROFILER_XHPROF:
+                return new Profilers\XHProf();
+            case Profiler::PROFILER_UPROFILER:
+                return new Profilers\UProfiler();
+            case Profiler::PROFILER_TIDEWAYS:
+                return new Profilers\Tideways();
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Profilers/AbstractProfiler.php
+++ b/src/Profilers/AbstractProfiler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Xhgui\Profiler\Profilers;
+
+abstract class AbstractProfiler
+{
+    /**
+     * Enable the specific profiler
+     *
+     * @param array $flags
+     * @param array $options
+     */
+    abstract public function enableWith($flags = array(), $options = array());
+
+    /**
+     * Disable (stop) the profiler. Return the collected data
+     *
+     * @return array
+     */
+    abstract public function disable();
+
+    /**
+     * Map generic Xhgui\Profiler\ProfilingFlags to {SPECIFIC_PROFILER_NAME_HERE} implementation
+     *
+     * @return array - array with the structure [generic_flag => specific_profiler_flag],
+     *                                      e.g. [ProfilingFlags::CPU => XHPROF_FLAGS_CPU]
+     */
+    abstract protected function getProfileFlagMap();
+
+    /**
+     * Combines flags using bitwise OR
+     *
+     * @param $flags
+     * @return int
+     */
+    protected function combineFlags($flags)
+    {
+        $combinedFlag = 0;
+
+        $flagMap = $this->getProfileFlagMap();
+        foreach ($flags as $flag) {
+            $mappedFlag = array_key_exists($flag, $flagMap) ? $flagMap[$flag] : $flag;
+            $combinedFlag |= $mappedFlag;
+        }
+
+        return $combinedFlag;
+    }
+}

--- a/src/Profilers/Tideways.php
+++ b/src/Profilers/Tideways.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Xhgui\Profiler\Profilers;
+
+use Xhgui\Profiler\ProfilingFlags;
+
+class Tideways extends AbstractProfiler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function enableWith($flags = array(), $options = array())
+    {
+        if (!in_array(TIDEWAYS_FLAGS_NO_SPANS, $flags, true)) {
+            $flags[] = TIDEWAYS_FLAGS_NO_SPANS;
+        }
+
+        tideways_enable($this->combineFlags($flags), $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disable()
+    {
+        return tideways_disable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getProfileFlagMap()
+    {
+        return array(
+            ProfilingFlags::CPU => TIDEWAYS_FLAGS_CPU,
+            ProfilingFlags::MEMORY => TIDEWAYS_FLAGS_MEMORY,
+        );
+    }
+}

--- a/src/Profilers/UProfiler.php
+++ b/src/Profilers/UProfiler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Xhgui\Profiler\Profilers;
+
+use Xhgui\Profiler\ProfilingFlags;
+
+class UProfiler extends AbstractProfiler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function enableWith($flags = array(), $options = array())
+    {
+        uprofiler_enable($this->combineFlags($flags), $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disable()
+    {
+        return uprofiler_disable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getProfileFlagMap()
+    {
+        return array(
+            ProfilingFlags::CPU => UPROFILER_FLAGS_CPU,
+            ProfilingFlags::MEMORY => UPROFILER_FLAGS_MEMORY,
+        );
+    }
+}

--- a/src/Profilers/XHProf.php
+++ b/src/Profilers/XHProf.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Xhgui\Profiler\Profilers;
+
+use Xhgui\Profiler\ProfilingFlags;
+
+class XHProf extends AbstractProfiler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function enableWith($flags = array(), $options = array())
+    {
+        if (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 4) {
+            $flags[] = XHPROF_FLAGS_NO_BUILTINS;
+        }
+
+        xhprof_enable($this->combineFlags($flags), $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disable()
+    {
+        return xhprof_disable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getProfileFlagMap()
+    {
+        return array(
+            ProfilingFlags::CPU => XHPROF_FLAGS_CPU,
+            ProfilingFlags::MEMORY => XHPROF_FLAGS_MEMORY,
+        );
+    }
+}

--- a/src/ProfilingFlags.php
+++ b/src/ProfilingFlags.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Xhgui\Profiler;
+
+final class ProfilingFlags
+{
+    const CPU = 'PROFILER_CPU_PROFILING';
+    const MEMORY = 'PROFILER_MEMORY_PROFILING';
+}


### PR DESCRIPTION
@lauripiisang and @glensc have discussed to opensource this library in 2017. @lauripiisang has given me verbal permission to do the transition.

I think this should be integrated to `perftools/xhgui-collector` project eventually, not add another abstraction.

This is based on 0.7.0, so for final project merge, need to apply changes from xhgui-collector repository.

Other option would be make this totally new package, move it to `perftools/php-profiler` organization, and remove dependency on `perftools/xhgui-collector` deprecate `perftools/xhgui-collector` package.

@markstory: let me know what you think.