### PR TITLE
Add NO_BUILTINS flags to profilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ try {
 		'profiler.flags' => array(
 			\Xhgui\Profiler\ProfilingFlags::CPU,
 			\Xhgui\Profiler\ProfilingFlags::MEMORY,
+			\Xhgui\Profiler\ProfilingFlags::NO_BUILTINS,
 		),
 		'profiler.options' => array(),
 	);

--- a/src/Profilers/Tideways.php
+++ b/src/Profilers/Tideways.php
@@ -34,6 +34,7 @@ class Tideways extends AbstractProfiler
         return array(
             ProfilingFlags::CPU => TIDEWAYS_FLAGS_CPU,
             ProfilingFlags::MEMORY => TIDEWAYS_FLAGS_MEMORY,
+            ProfilingFlags::NO_BUILTINS => TIDEWAYS_FLAGS_NO_BUILTINS,
         );
     }
 }

--- a/src/Profilers/UProfiler.php
+++ b/src/Profilers/UProfiler.php
@@ -30,6 +30,7 @@ class UProfiler extends AbstractProfiler
         return array(
             ProfilingFlags::CPU => UPROFILER_FLAGS_CPU,
             ProfilingFlags::MEMORY => UPROFILER_FLAGS_MEMORY,
+            ProfilingFlags::NO_BUILTINS => UPROFILER_FLAGS_NO_BUILTINS,
         );
     }
 }

--- a/src/Profilers/XHProf.php
+++ b/src/Profilers/XHProf.php
@@ -11,10 +11,6 @@ class XHProf extends AbstractProfiler
      */
     public function enableWith($flags = array(), $options = array())
     {
-        if (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 4) {
-            $flags[] = XHPROF_FLAGS_NO_BUILTINS;
-        }
-
         xhprof_enable($this->combineFlags($flags), $options);
     }
 
@@ -31,9 +27,17 @@ class XHProf extends AbstractProfiler
      */
     public function getProfileFlagMap()
     {
+        /*
+         * This is disabled on PHP 5.5+ as it causes a segfault
+         *
+         * @see https://github.com/perftools/xhgui-collector/commit/d1236d6422bfc42ac212befd0968036986885ccd
+         */
+        $noBuiltins = PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION > 4 ? 0 : XHPROF_FLAGS_NO_BUILTINS;
+
         return array(
             ProfilingFlags::CPU => XHPROF_FLAGS_CPU,
             ProfilingFlags::MEMORY => XHPROF_FLAGS_MEMORY,
+            ProfilingFlags::NO_BUILTINS => $noBuiltins,
         );
     }
 }

--- a/src/ProfilingFlags.php
+++ b/src/ProfilingFlags.php
@@ -6,4 +6,5 @@ final class ProfilingFlags
 {
     const CPU = 'PROFILER_CPU_PROFILING';
     const MEMORY = 'PROFILER_MEMORY_PROFILING';
+    const NO_BUILTINS = 'NO_BUILTINS';
 }


### PR DESCRIPTION
This adds new `ProfilingFlags::NO_BUILTINS` that can be enabled.

Prior code enabled the flag automatically for XHProf only.

- https://github.com/perftools/xhgui-collector/issues/32
- https://github.com/perftools/xhgui-collector/pull/33
- https://github.com/perftools/xhgui/pull/277