### PR TITLE
Setup .travis.yml configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ cache:
 
 install:
   - composer install --no-interaction --prefer-dist
-  - composer require --dev symfony/phpunit-bridge
+  - composer require --dev phpunit/phpunit
 
 script:
-  - vendor/bin/simple-phpunit --version
-  - vendor/bin/simple-phpunit --verbose
+  - vendor/bin/phpunit --version
+  - vendor/bin/phpunit --verbose
 
 # vim:ts=2:sw=2:et

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,20 @@ jobs:
   include:
     - php: "5.3"
       dist: precise
+      env:
+      - PHPUNIT_VERSION=4.8
     - php: "5.4"
+      env:
+      - PHPUNIT_VERSION=4.8
     - php: "5.5"
+      env:
+      - PHPUNIT_VERSION=4.8
     - php: "5.6"
+      env:
+      - PHPUNIT_VERSION=5.7
     - php: "7.0"
+      env:
+      - PHPUNIT_VERSION=6.5
     - php: "7.1"
     - php: "7.2"
     - php: "7.3"
@@ -30,7 +40,7 @@ cache:
 
 install:
   - composer install --no-interaction --prefer-dist
-  - composer require --dev phpunit/phpunit:$PHPUNIT_VERSION
+  - composer require --dev phpunit/phpunit:^$PHPUNIT_VERSION
 
 script:
   - vendor/bin/phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: php
+sudo: false
+dist: trusty
+
+jobs:
+  fast_finish: true
+  allow_failures:
+    - php: "nightly"
+  include:
+    - php: "5.3"
+      dist: precise
+    - php: "5.4"
+    - php: "5.5"
+    - php: "5.6"
+    - php: "7.0"
+    - php: "7.1"
+    - php: "7.2"
+    - php: "7.3"
+    - php: "7.4"
+    - php: "nightly"
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+install:
+  - composer install --no-interaction --prefer-dist
+
+script:
+  - vendor/bin/simple-phpunit --version
+  - vendor/bin/simple-phpunit --verbose
+
+# vim:ts=2:sw=2:et

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ cache:
 
 install:
   - composer install --no-interaction --prefer-dist
+  - composer require --dev symfony/phpunit-bridge
 
 script:
   - vendor/bin/simple-phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+os: linux
 dist: trusty
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ cache:
 install:
   - composer install --no-interaction --prefer-dist
   - composer require --dev phpunit/phpunit:^$PHPUNIT_VERSION
+  - ./install-extensions.sh
 
 script:
   - vendor/bin/phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 sudo: false
 dist: trusty
 
+env:
+  - PHPUNIT_VERSION=7.5
+
 jobs:
   fast_finish: true
   allow_failures:
@@ -27,7 +30,7 @@ cache:
 
 install:
   - composer install --no-interaction --prefer-dist
-  - composer require --dev phpunit/phpunit
+  - composer require --dev phpunit/phpunit:$PHPUNIT_VERSION
 
 script:
   - vendor/bin/phpunit --version

--- a/README.md
+++ b/README.md
@@ -3,20 +3,22 @@
 A PHP profiling library based on [XHGUI Data Collector][1].
 
 Supported profilers:
- - XHProf - PHP >= 5.3, < PHP 7.0
- - Tideways - PHP >= 7.0
+ - Tideways XHProf v5.x - PHP >= 7.0
+ - Tideways v4.x - PHP >= 7.0
  - UProfiler - PHP >= 5.3, < PHP 7.0
+ - XHProf - PHP >= 5.3, < PHP 7.0
 
 [XHProf]: https://pecl.php.net/package/xhprof
 [Tideways]: https://github.com/tideways/php-xhprof-extension
+[Tideways XHProf]: https://github.com/tideways/php-xhprof-extension
 [UProfiler]: https://github.com/FriendsOfPHP/uprofiler
 
 This profiling library will auto-detect what you have installed and use that.
 
 The preference order is currently as follows:
-1. uprofiler
 1. tideways_xhprof
 1. tideways
+1. uprofiler
 1. xhprof
 
 DON'T RELY ON THIS PREFERENCE ORDER IN PRODUCTION ENVIRONMENTS.

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,5 @@
 		"ext-mongo": "mongo extension (PHP>=5.3,<7.0)",
 		"ext-mongodb": "mongodb extension (PHP>=5.4,<7.3)",
 		"alcaeus/mongo-php-adapter": "Adapter to provide ext-mongo interface on top of mongo-php-libary"
-	},
-	"require-dev": {
-		"symfony/phpunit-bridge": "^4.2||^5.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		}
 	},
 	"require": {
-		"php": "^5.3.0 || ^7.0",
+		"php": "^5.3.0 || ^7.0 || ^8.0",
 		"perftools/xhgui-collector": "^1.1.0"
 	},
 	"suggest": {

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -xeu
+
+: ${TRAVIS_PHP_VERSION=7.4}
+: ${TIDEWAYS_VERSION=4.1.4}
+: ${TIDEWAYS_XHPROF_VERSION=5.0.2}
+: ${PHP_VERSION=${TRAVIS_PHP_VERSION}}
+
+install_tideways_xhprof() {
+	local version=$TIDEWAYS_XHPROF_VERSION
+	local url="https://github.com/tideways/php-xhprof-extension/releases/download/v$version/tideways-xhprof-$version-x86_64.tar.gz"
+	local tar="tideways_xhprof.tgz"
+	local config extension
+
+	curl -fL -o "$tar" "$url"
+	tar -xvf "$tar"
+
+	extension="$PWD/tideways_xhprof-$version/tideways_xhprof-$PHP_VERSION.so"
+	config="$HOME/.phpenv/versions/$PHP_VERSION/etc/tideways_xhprof.ini"
+	echo "extension=$extension" > "$config"
+}
+
+case "$PHP_VERSION" in
+7.*)
+	install_tideways_xhprof
+	;;
+esac

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,8 +19,8 @@
 	</testsuites>
 
 	<php>
-		<server name="SYMFONY_PHPUNIT_VERSION" value="4.8" />
 	<!--
+		<server name="SYMFONY_PHPUNIT_VERSION" value="4.8" />
 		<ini name="date.timezone" value="UTC" />
 		<server name="KERNEL_DIR" value="/path/to/your/app/" />
 		<env name="KERNEL_CLASS" value="App\Kernel"/>

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -140,9 +140,9 @@ class Profiler
      * Determines which profiler you're running.
      * If you're running multiple (which you shouldn't!),
      * It will return them in this preference order:
-     * 1) uprofiler
      * 2) tideways_xhprof
      * 2) tideways
+     * 1) uprofiler
      * 3) xhprof
      *
      * @return string|null
@@ -153,8 +153,8 @@ class Profiler
         // NOTE: the list here is reversed
         $extensions = array(
             self::PROFILER_XHPROF,
-            self::PROFILER_TIDEWAYS,
             self::PROFILER_UPROFILER,
+            self::PROFILER_TIDEWAYS,
             self::PROFILER_TIDEWAYS_XHPROF,
         );
         foreach ($extensions as $extension) {


### PR DESCRIPTION
Followup to https://github.com/perftools/php-profiler/pull/5

- Adds php 5.3-5.6, 7.0-7.4
- Adds `tideways_xhprof` for php 7.x