### PR TITLE
Add NO_SPANS flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ try {
 			\Xhgui\Profiler\ProfilingFlags::CPU,
 			\Xhgui\Profiler\ProfilingFlags::MEMORY,
 			\Xhgui\Profiler\ProfilingFlags::NO_BUILTINS,
+			\Xhgui\Profiler\ProfilingFlags::NO_SPANS,
 		),
 		'profiler.options' => array(),
 	);
@@ -102,6 +103,8 @@ Configuration unique to this package:
 |----------------------|-------|--------------------------------------------------|---------------|
 | profiler.flags       | array | Array of [ProfilingFlags][2]                     | empty array   |
 | profiler.options     | array | Array of options to pass to profiler enable call | empty array   |
+
+Flags that are not supported by specific profiler, will be ignored.
 
 What you'll likely need to configure when instructing an app to use this profiling:
 

--- a/src/Profilers/Tideways.php
+++ b/src/Profilers/Tideways.php
@@ -11,10 +11,6 @@ class Tideways extends AbstractProfiler
      */
     public function enableWith($flags = array(), $options = array())
     {
-        if (!in_array(TIDEWAYS_FLAGS_NO_SPANS, $flags, true)) {
-            $flags[] = TIDEWAYS_FLAGS_NO_SPANS;
-        }
-
         tideways_enable($this->combineFlags($flags), $options);
     }
 
@@ -35,6 +31,7 @@ class Tideways extends AbstractProfiler
             ProfilingFlags::CPU => TIDEWAYS_FLAGS_CPU,
             ProfilingFlags::MEMORY => TIDEWAYS_FLAGS_MEMORY,
             ProfilingFlags::NO_BUILTINS => TIDEWAYS_FLAGS_NO_BUILTINS,
+            ProfilingFlags::NO_SPANS => TIDEWAYS_FLAGS_NO_SPANS,
         );
     }
 }

--- a/src/Profilers/UProfiler.php
+++ b/src/Profilers/UProfiler.php
@@ -31,6 +31,7 @@ class UProfiler extends AbstractProfiler
             ProfilingFlags::CPU => UPROFILER_FLAGS_CPU,
             ProfilingFlags::MEMORY => UPROFILER_FLAGS_MEMORY,
             ProfilingFlags::NO_BUILTINS => UPROFILER_FLAGS_NO_BUILTINS,
+            ProfilingFlags::NO_SPANS => 0,
         );
     }
 }

--- a/src/Profilers/XHProf.php
+++ b/src/Profilers/XHProf.php
@@ -38,6 +38,7 @@ class XHProf extends AbstractProfiler
             ProfilingFlags::CPU => XHPROF_FLAGS_CPU,
             ProfilingFlags::MEMORY => XHPROF_FLAGS_MEMORY,
             ProfilingFlags::NO_BUILTINS => $noBuiltins,
+            ProfilingFlags::NO_SPANS => 0,
         );
     }
 }

--- a/src/ProfilingFlags.php
+++ b/src/ProfilingFlags.php
@@ -7,4 +7,5 @@ final class ProfilingFlags
     const CPU = 'PROFILER_CPU_PROFILING';
     const MEMORY = 'PROFILER_MEMORY_PROFILING';
     const NO_BUILTINS = 'NO_BUILTINS';
+    const NO_SPANS = 'NO_SPANS';
 }


### PR DESCRIPTION
This is added based on current codebase, even if the profiler may
actually support the flag.

Previously Tideways profiler added this flag automatically,
making it impossible to skip the flag.