### PR TITLE
Move logic if Profiler can work to Profiler classes

### DIFF
--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -91,7 +91,7 @@ class Profiler
             return;
         }
 
-        $profiler->enableWith($this->config['profiler.flags'], $this->config['profiler.options']);
+        $profiler->enable($this->config['profiler.flags'], $this->config['profiler.options']);
         $this->running = true;
     }
 

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -28,11 +28,6 @@ class Profiler
      */
     private $config;
 
-    const PROFILER_XHPROF = 'xhprof';
-    const PROFILER_TIDEWAYS = 'tideways';
-    const PROFILER_TIDEWAYS_XHPROF = 'tideways_xhprof';
-    const PROFILER_UPROFILER = 'uprofiler';
-
     /**
      * @var Xhgui_Saver_Interface
      */

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -68,8 +68,8 @@ class Profiler
         $this->config = array_replace($this->getDefaultConfig(), $config);
         $shouldRunFunction = $this->config['profiler.enable'];
         $this->shouldRun = is_callable($shouldRunFunction) ? $shouldRunFunction() : false;
-        if (!$this->validateExtensionsInstalled()) {
-            throw new RuntimeException('Unable to create profiler: cannot find extensions');
+        if (!$this->getProfiler()) {
+            throw new RuntimeException('Unable to create profiler: no suitable profiler found');
         }
         if (!$this->canSave()) {
             throw new RuntimeException('Unable to create profiler: unable to save data');
@@ -91,14 +91,22 @@ class Profiler
             $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
         }
 
-        $profiler = ProfilerFactory::make($this->getProfilerType());
-        if (!($profiler instanceof ProfilerInterface)) {
+        $profiler = $this->getProfiler();
+        if (!$profiler) {
             return;
         }
 
         $profiler->enableWith($this->config['profiler.flags'], $this->config['profiler.options']);
-        $this->profiler = $profiler;
         $this->running = true;
+    }
+
+    private function getProfiler()
+    {
+        if ($this->profiler === null) {
+            $this->profiler = ProfilerFactory::create() ?: false;
+        }
+
+        return $this->profiler ?: null;
     }
 
     /**
@@ -134,42 +142,6 @@ class Profiler
         } catch (Exception $e) {
             return;
         }
-    }
-
-    /**
-     * Determines which profiler you're running.
-     * If you're running multiple (which you shouldn't!),
-     * It will return them in this preference order:
-     * 2) tideways_xhprof
-     * 2) tideways
-     * 1) uprofiler
-     * 3) xhprof
-     *
-     * @return string|null
-     */
-    private function getProfilerType()
-    {
-        $profiler = null;
-        // NOTE: the list here is reversed
-        $extensions = array(
-            self::PROFILER_XHPROF,
-            self::PROFILER_UPROFILER,
-            self::PROFILER_TIDEWAYS,
-            self::PROFILER_TIDEWAYS_XHPROF,
-        );
-        foreach ($extensions as $extension) {
-            $profiler = extension_loaded($extension) ? $extension : $profiler;
-        }
-
-        return $profiler;
-    }
-
-    /**
-     * @return bool
-     */
-    private function validateExtensionsInstalled()
-    {
-        return $this->getProfilerType() && (extension_loaded('mongo') || extension_loaded('mongodb'));
     }
 
     /**

--- a/src/ProfilerFactory.php
+++ b/src/ProfilerFactory.php
@@ -7,20 +7,30 @@ use Xhgui\Profiler\Profilers\ProfilerInterface;
 final class ProfilerFactory
 {
     /**
-     * @param string|null $profilerType
+     * Creates Profiler instance that can be used.
+     *
+     * If you're running multiple (which you shouldn't!),
+     * It will test them in this preference order:
+     * 2) tideways_xhprof
+     * 2) tideways
+     * 1) uprofiler
+     * 3) xhprof
+     *
      * @return ProfilerInterface|null
      */
-    public static function make($profilerType)
+    public static function create()
     {
-        switch ($profilerType) {
-            case Profiler::PROFILER_XHPROF:
-                return new Profilers\XHProf();
-            case Profiler::PROFILER_UPROFILER:
-                return new Profilers\UProfiler();
-            case Profiler::PROFILER_TIDEWAYS:
-                return new Profilers\Tideways();
-            default:
-                return null;
-        }
+        $adapters = array(
+            new Profilers\TidewaysXHProf(),
+            new Profilers\Tideways(),
+            new Profilers\UProfiler(),
+            new Profilers\XHProf(),
+        );
+
+        $available = array_filter($adapters, function (ProfilerInterface $adapter) {
+            return $adapter->isSupported();
+        });
+
+        return current($available) ?: null;
     }
 }

--- a/src/Profilers/AbstractProfiler.php
+++ b/src/Profilers/AbstractProfiler.php
@@ -5,6 +5,14 @@ namespace Xhgui\Profiler\Profilers;
 abstract class AbstractProfiler implements ProfilerInterface
 {
     /**
+     * @deprecated use enabe() method
+     */
+    public function enableWith($flags = array(), $options = array())
+    {
+        return $this->enable($flags, $options);
+    }
+
+    /**
      * Combines flags using bitwise OR
      *
      * @param array $flags

--- a/src/Profilers/ProfilerInterface.php
+++ b/src/Profilers/ProfilerInterface.php
@@ -5,6 +5,11 @@ namespace Xhgui\Profiler\Profilers;
 interface ProfilerInterface
 {
     /**
+     * @return bool
+     */
+    public function isSupported();
+
+    /**
      * Enable the specific profiler
      *
      * @param array $flags

--- a/src/Profilers/ProfilerInterface.php
+++ b/src/Profilers/ProfilerInterface.php
@@ -10,12 +10,13 @@ interface ProfilerInterface
     public function isSupported();
 
     /**
-     * Enable the specific profiler
+     * Enable profiling with current adapter.
+     * The profiler may not support all flags and options, in this case those are ignored.
      *
      * @param array $flags
      * @param array $options
      */
-    public function enableWith($flags = array(), $options = array());
+    public function enable($flags = array(), $options = array());
 
     /**
      * Disable (stop) the profiler. Return the collected data

--- a/src/Profilers/Tideways.php
+++ b/src/Profilers/Tideways.php
@@ -18,7 +18,7 @@ class Tideways extends AbstractProfiler
         return extension_loaded(self::EXTENSION_NAME);
     }
 
-    public function enableWith($flags = array(), $options = array())
+    public function enable($flags = array(), $options = array())
     {
         tideways_enable($this->combineFlags($flags), $options);
     }

--- a/src/Profilers/Tideways.php
+++ b/src/Profilers/Tideways.php
@@ -11,9 +11,13 @@ use Xhgui\Profiler\ProfilingFlags;
  */
 class Tideways extends AbstractProfiler
 {
-    /**
-     * {@inheritdoc}
-     */
+    const EXTENSION_NAME = 'tideways';
+
+    public function isSupported()
+    {
+        return extension_loaded(self::EXTENSION_NAME);
+    }
+
     public function enableWith($flags = array(), $options = array())
     {
         tideways_enable($this->combineFlags($flags), $options);

--- a/src/Profilers/TidewaysXHProf.php
+++ b/src/Profilers/TidewaysXHProf.php
@@ -18,7 +18,7 @@ class TidewaysXHProf extends AbstractProfiler
         return extension_loaded(self::EXTENSION_NAME);
     }
 
-    public function enableWith($flags = array(), $options = array())
+    public function enable($flags = array(), $options = array())
     {
         tideways_xhprof_enable($this->combineFlags($flags));
     }

--- a/src/Profilers/TidewaysXHProf.php
+++ b/src/Profilers/TidewaysXHProf.php
@@ -11,9 +11,13 @@ use Xhgui\Profiler\ProfilingFlags;
  */
 class TidewaysXHProf extends AbstractProfiler
 {
-    /**
-     * {@inheritdoc}
-     */
+    const EXTENSION_NAME = 'tideways_xhprof';
+
+    public function isSupported()
+    {
+        return extension_loaded(self::EXTENSION_NAME);
+    }
+
     public function enableWith($flags = array(), $options = array())
     {
         tideways_xhprof_enable($this->combineFlags($flags), $options);

--- a/src/Profilers/TidewaysXHProf.php
+++ b/src/Profilers/TidewaysXHProf.php
@@ -20,7 +20,7 @@ class TidewaysXHProf extends AbstractProfiler
 
     public function enableWith($flags = array(), $options = array())
     {
-        tideways_xhprof_enable($this->combineFlags($flags), $options);
+        tideways_xhprof_enable($this->combineFlags($flags));
     }
 
     /**

--- a/src/Profilers/UProfiler.php
+++ b/src/Profilers/UProfiler.php
@@ -6,9 +6,13 @@ use Xhgui\Profiler\ProfilingFlags;
 
 class UProfiler extends AbstractProfiler
 {
-    /**
-     * {@inheritdoc}
-     */
+    const EXTENSION_NAME = 'uprofiler';
+
+    public function isSupported()
+    {
+        return extension_loaded(self::EXTENSION_NAME);
+    }
+
     public function enableWith($flags = array(), $options = array())
     {
         uprofiler_enable($this->combineFlags($flags), $options);

--- a/src/Profilers/UProfiler.php
+++ b/src/Profilers/UProfiler.php
@@ -13,7 +13,7 @@ class UProfiler extends AbstractProfiler
         return extension_loaded(self::EXTENSION_NAME);
     }
 
-    public function enableWith($flags = array(), $options = array())
+    public function enable($flags = array(), $options = array())
     {
         uprofiler_enable($this->combineFlags($flags), $options);
     }

--- a/src/Profilers/XHProf.php
+++ b/src/Profilers/XHProf.php
@@ -13,7 +13,7 @@ class XHProf extends AbstractProfiler
         return extension_loaded(self::EXTENSION_NAME);
     }
 
-    public function enableWith($flags = array(), $options = array())
+    public function enable($flags = array(), $options = array())
     {
         xhprof_enable($this->combineFlags($flags), $options);
     }

--- a/src/Profilers/XHProf.php
+++ b/src/Profilers/XHProf.php
@@ -6,9 +6,13 @@ use Xhgui\Profiler\ProfilingFlags;
 
 class XHProf extends AbstractProfiler
 {
-    /**
-     * {@inheritdoc}
-     */
+    const EXTENSION_NAME = 'xhprof';
+
+    public function isSupported()
+    {
+        return extension_loaded(self::EXTENSION_NAME);
+    }
+
     public function enableWith($flags = array(), $options = array())
     {
         xhprof_enable($this->combineFlags($flags), $options);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function runProfiler($flags = array(), $options = array())
     {
-        $this->profiler->enableWith($flags, $options);
+        $this->profiler->enable($flags, $options);
         $data = $this->profiler->disable();
         $this->assertNotEmpty($data);
 

--- a/tests/TidewaysTest.php
+++ b/tests/TidewaysTest.php
@@ -18,7 +18,7 @@ class TidewaysTest extends TestCase
     public function testDefaults()
     {
         $data = $this->runProfiler();
-        $this->assertCount(3, $data);
+        $this->assertCount(2, $data);
     }
 
     public function testNoFlags()


### PR DESCRIPTION
Move logic if Profiler can work to individual Profiler classes. The Profiler main class had too many responsibilities.