### PR TITLE
Add Saver classes to this project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
 	"suggest": {
 		"ext-mongo": "mongo extension (PHP>=5.3,<7.0)",
 		"ext-mongodb": "mongodb extension (PHP>=5.4,<7.3)",
-		"alcaeus/mongo-php-adapter": "Adapter to provide ext-mongo interface on top of mongo-php-libary"
+		"alcaeus/mongo-php-adapter": "Adapter to provide ext-mongo interface on top of mongo-php-libary (PHP>=5.6)"
+	},
+	"require-dev": {
+		"ext-json": "*"
 	}
 }

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -3,10 +3,7 @@
 namespace Xhgui\Profiler;
 
 use Exception;
-use MongoCursorException;
-use MongoCursorTimeoutException;
 use MongoDate;
-use MongoException;
 use RuntimeException;
 use Xhgui\Profiler\Profilers\ProfilerInterface;
 use Xhgui\Profiler\Saver\SaverInterface;
@@ -266,10 +263,6 @@ class Profiler
 
     /**
      * Stop profiling. Get currently collected data and save it
-     *
-     * @throws MongoException
-     * @throws MongoCursorException
-     * @throws MongoCursorTimeoutException
      */
     public function stop()
     {

--- a/src/Saver/AbstractSaver.php
+++ b/src/Saver/AbstractSaver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+use Xhgui_Saver_Interface;
+
+abstract class AbstractSaver implements SaverInterface
+{
+    protected $saver;
+
+    public function __construct(Xhgui_Saver_Interface $saver)
+    {
+        $this->saver = $saver;
+    }
+
+    public function save(array $data)
+    {
+        return $this->saver->save($data);
+    }
+}

--- a/src/Saver/AbstractSaver.php
+++ b/src/Saver/AbstractSaver.php
@@ -17,4 +17,9 @@ abstract class AbstractSaver implements SaverInterface
     {
         return $this->saver->save($data);
     }
+
+    public function getHandler()
+    {
+        return $this->saver;
+    }
 }

--- a/src/Saver/FileSaver.php
+++ b/src/Saver/FileSaver.php
@@ -2,6 +2,37 @@
 
 namespace Xhgui\Profiler\Saver;
 
-class FileSaver extends \Xhgui_Saver_File implements SaverInterface
+use Exception;
+use ReflectionClass;
+use Xhgui_Saver_File;
+
+/**
+ * @property Xhgui_Saver_File $saver
+ */
+class FileSaver extends AbstractSaver
 {
+    public function isSupported()
+    {
+        if (!$this->saver instanceof Xhgui_Saver_File) {
+            return false;
+        }
+        if (!function_exists('json_encode')) {
+            return false;
+        }
+
+        try {
+            return is_writable(dirname($this->getSaveFile()));
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    private function getSaveFile()
+    {
+        $rc = new ReflectionClass($this->saver);
+        $property = $rc->getProperty('_file');
+        $property->setAccessible(true);
+
+        return $property->getValue($this->saver);
+    }
 }

--- a/src/Saver/FileSaver.php
+++ b/src/Saver/FileSaver.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+class FileSaver extends \Xhgui_Saver_File implements SaverInterface
+{
+}

--- a/src/Saver/MongoSaver.php
+++ b/src/Saver/MongoSaver.php
@@ -4,6 +4,17 @@ namespace Xhgui\Profiler\Saver;
 
 use Xhgui_Saver_Mongo;
 
-class MongoSaver extends Xhgui_Saver_Mongo implements SaverInterface
+/**
+ * @property Xhgui_Saver_Mongo $saver
+ */
+class MongoSaver extends AbstractSaver
 {
+    public function isSupported()
+    {
+        if (!$this->saver instanceof Xhgui_Saver_Mongo) {
+            return false;
+        }
+
+        return class_exists('MongoClient');
+    }
 }

--- a/src/Saver/MongoSaver.php
+++ b/src/Saver/MongoSaver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+use Xhgui_Saver_Mongo;
+
+class MongoSaver extends Xhgui_Saver_Mongo implements SaverInterface
+{
+}

--- a/src/Saver/PdoSaver.php
+++ b/src/Saver/PdoSaver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+use Xhgui_Saver_Pdo;
+
+class PdoSaver extends Xhgui_Saver_Pdo implements SaverInterface
+{
+}

--- a/src/Saver/PdoSaver.php
+++ b/src/Saver/PdoSaver.php
@@ -4,6 +4,17 @@ namespace Xhgui\Profiler\Saver;
 
 use Xhgui_Saver_Pdo;
 
-class PdoSaver extends Xhgui_Saver_Pdo implements SaverInterface
+/**
+ * @property Xhgui_Saver_Pdo $saver
+ */
+class PdoSaver extends AbstractSaver
 {
+    public function isSupported()
+    {
+        if (!$this->saver instanceof Xhgui_Saver_Pdo) {
+            return false;
+        }
+
+        return class_exists('PDO');
+    }
 }

--- a/src/Saver/SaverInterface.php
+++ b/src/Saver/SaverInterface.php
@@ -6,4 +6,8 @@ use Xhgui_Saver_Interface;
 
 interface SaverInterface extends Xhgui_Saver_Interface
 {
+    /**
+     * @return bool
+     */
+    public function isSupported();
 }

--- a/src/Saver/SaverInterface.php
+++ b/src/Saver/SaverInterface.php
@@ -10,4 +10,9 @@ interface SaverInterface extends Xhgui_Saver_Interface
      * @return bool
      */
     public function isSupported();
+
+    /**
+     * @return Xhgui_Saver_Interface
+     */
+    public function getHandler();
 }

--- a/src/Saver/SaverInterface.php
+++ b/src/Saver/SaverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+use Xhgui_Saver_Interface;
+
+interface SaverInterface extends Xhgui_Saver_Interface
+{
+}

--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -4,6 +4,17 @@ namespace Xhgui\Profiler\Saver;
 
 use Xhgui_Saver_Upload;
 
-class UploadSaver extends Xhgui_Saver_Upload implements SaverInterface
+/**
+ * @property Xhgui_Saver_Upload $saver
+ */
+class UploadSaver extends AbstractSaver
 {
+    public function isSupported()
+    {
+        if (!$this->saver instanceof Xhgui_Saver_Upload) {
+            return false;
+        }
+
+        return function_exists('json_encode') && function_exists('curl_init');
+    }
 }

--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+use Xhgui_Saver_Upload;
+
+class UploadSaver extends Xhgui_Saver_Upload implements SaverInterface
+{
+}

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Xhgui\Profiler;
+
+use Xhgui\Profiler\Saver\SaverInterface;
+use Xhgui_Saver;
+use Xhgui_Saver_Interface;
+
+final class SaverFactory
+{
+    /**
+     * @param string $saveHandler
+     * @param array $config
+     * @return SaverInterface|null
+     */
+    public static function create($saveHandler, array $config = array())
+    {
+        $config['save.handler'] = $saveHandler;
+        $saver = Xhgui_Saver::factory($config);
+
+        return static::getAdapter($saver);
+    }
+
+    private static function getAdapter(Xhgui_Saver_Interface $saver)
+    {
+        $adapters = array(
+            new Saver\FileSaver($saver),
+            new Saver\PdoSaver($saver),
+            new Saver\MongoSaver($saver),
+            new Saver\UploadSaver($saver),
+        );
+
+        $available = array_filter($adapters, function (SaverInterface $adapter) {
+            return $adapter->isSupported();
+        });
+
+        return current($available) ?: null;
+    }
+}

--- a/tests/Saver/FileSaverTest.php
+++ b/tests/Saver/FileSaverTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Xhgui\Profiler\Test\Saver;
+
+use Xhgui\Profiler\Saver\FileSaver;
+use Xhgui\Profiler\Test\TestCase;
+
+/**
+ * @requires extension json
+ * @property FileSaver $saver
+ */
+class FileSaverTest extends TestCase
+{
+    public function setUp()
+    {
+        $config = array(
+            'save.handler.filename' => sys_get_temp_dir() . '/php-profiler-test-save.json',
+        );
+        $this->saver = $this->createSaver('file', $config);
+    }
+
+    public function testSaveEmpty()
+    {
+        $this->saver->save(array());
+    }
+}

--- a/tests/Saver/MongoSaverTest.php
+++ b/tests/Saver/MongoSaverTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Xhgui\Profiler\Test\Saver;
+
+use Xhgui\Profiler\Saver\MongoSaver;
+use Xhgui\Profiler\Test\TestCase;
+
+/**
+ * @requires extension mongodb
+ * @property MongoSaver $saver
+ */
+class MongoSaverTest extends TestCase
+{
+    public function setUp()
+    {
+        $config = array(
+            'db.host' => 'mongodb://127.0.0.1:27017',
+            'db.db' => getenv('XHGUI_MONGO_DB') ?: 'xhprof',
+            'db.options' => array(),
+        );
+        $this->saver = $this->createSaver('mongodb', $config);
+    }
+
+    public function testSaveEmpty()
+    {
+        $this->saver->save(array());
+    }
+}

--- a/tests/Saver/PdoSaverTest.php
+++ b/tests/Saver/PdoSaverTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Xhgui\Profiler\Test\Saver;
+
+use Xhgui\Profiler\Saver\PdoSaver;
+use Xhgui\Profiler\Test\TestCase;
+
+/**
+ * @requires extension pdo
+ * @property PdoSaver $saver
+ */
+class PdoSaverTest extends TestCase
+{
+    public function setUp()
+    {
+        $config = array(
+            'pdo' => array(
+                'dsn' => sprintf('sqlite:%s/php-profiler-test-save.sqlite3', sys_get_temp_dir()),
+                'user' => 'xhgui',
+                'pass' => 'xhgui',
+                'table' => 'xhgui',
+            ),
+        );
+        $this->saver = $this->createSaver('pdo', $config);
+    }
+
+    public function testSaveEmpty()
+    {
+        $data = $this->getSample('session_meta.json');
+        $data['profile'] = $this->getSample('tideways_xhprof_cpu_memory.json');
+
+        $this->saver->save($data);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,14 @@
 namespace Xhgui\Profiler\Test;
 
 use Xhgui\Profiler\Profilers\ProfilerInterface;
+use Xhgui\Profiler\Saver\SaverInterface;
+use Xhgui\Profiler\SaverFactory;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    /** @var SaverInterface */
+    protected $saver;
+
     /** @var ProfilerInterface */
     protected $profiler;
 
@@ -16,5 +21,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $this->assertNotEmpty($data);
 
         return $data;
+    }
+
+    protected function createSaver($saveHandler, array $config = array())
+    {
+        $saver = SaverFactory::create($saveHandler, $config);
+        $this->assertNotNull($saver);
+
+        return $saver;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,18 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /** @var ProfilerInterface */
     protected $profiler;
 
+    protected function getSample($sampleName)
+    {
+        $file = __DIR__ . '/Resources/' . $sampleName;
+        $this->assertFileExists($file);
+        $contents = file_get_contents($file);
+        $this->assertNotEmpty($contents);
+        $sample = json_decode($contents, true);
+        $this->assertNotEmpty($sample);
+
+        return $sample;
+    }
+
     protected function runProfiler($flags = array(), $options = array())
     {
         $this->profiler->enable($flags, $options);


### PR DESCRIPTION
Removes too many responsibilities in the main class, a [Single-responsibility principle] violation of [SOLID].

This also lessens a bit tight integration with MongoClient, there are still things present.

[Single-responsibility principle]: https://en.wikipedia.org/wiki/Single-responsibility_principle
[SOLID]: https://en.wikipedia.org/wiki/SOLID

The Saver classes here are lightweight proxies to xhgui-collector Savers.

The weird constructs present are to keep using savers from xhgui-collector. Using own savers can be done in the future when this library has been proven useful.