### PR TITLE
Filter out environment keys from profiling data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ try {
 			\Xhgui\Profiler\ProfilingFlags::NO_SPANS,
 		),
 		'profiler.options' => array(),
+
+		// Environment variables to exclude from profiling data
+		'profiler.exclude-env' => array(
+			'APP_DATABASE_PASSWORD',
+			'PATH',
+		),
+
 		/**
 		 * Determine whether profiler should run.
 		 * This default implementation just disables the profiler.

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -217,7 +217,7 @@ class Profiler
             return array();
         }
 
-        $profile = new ProfilingData($this->profiler->disable());
+        $profile = new ProfilingData($this->profiler->disable(), $this->config);
         $this->running = false;
 
         return $profile->getProfilingData();

--- a/src/ProfilingData.php
+++ b/src/ProfilingData.php
@@ -9,7 +9,7 @@ class ProfilingData
     /** @var array */
     private $profile;
 
-    public function __construct(array $profile)
+    public function __construct(array $profile, array $config = array())
     {
         $this->profile = $profile;
     }

--- a/src/ProfilingData.php
+++ b/src/ProfilingData.php
@@ -82,7 +82,7 @@ class ProfilingData
      * @param array $env
      * @return array
      */
-    private function getEnvironment($env)
+    private function getEnvironment(array $env)
     {
         foreach ($this->excludeEnv as $key) {
             unset($env[$key]);

--- a/src/ProfilingData.php
+++ b/src/ProfilingData.php
@@ -9,9 +9,13 @@ class ProfilingData
     /** @var array */
     private $profile;
 
+    /** @var array */
+    private $excludeEnv;
+
     public function __construct(array $profile, array $config = array())
     {
         $this->profile = $profile;
+        $this->excludeEnv = isset($config['profiler.exclude-env']) ? (array)$config['profiler.exclude-env'] : array();
     }
 
     /**
@@ -58,7 +62,7 @@ class ProfilingData
         $meta = array(
             'url' => $uri,
             'get' => $_GET,
-            'env' => $_ENV,
+            'env' => $this->getEnvironment($_ENV),
             'SERVER' => $serverMeta,
             'simple_url' => Xhgui_Util::simpleUrl($uri),
             'request_ts' => $requestTs,
@@ -72,5 +76,18 @@ class ProfilingData
         );
 
         return $data;
+    }
+
+    /**
+     * @param array $env
+     * @return array
+     */
+    private function getEnvironment($env)
+    {
+        foreach ($this->excludeEnv as $key) {
+            unset($env[$key]);
+        }
+
+        return $env;
     }
 }


### PR DESCRIPTION
Makes it possible to exclude certain environment variables from profiling data:

```php
		// Environment variables to exclude from profiling data
		'profiler.exclude-env' => array(
			'APP_DATABASE_PASSWORD',
			'PATH',
		),
```

Fixes https://github.com/perftools/xhgui/pull/286