### PR TITLE
Add token support for upload saver

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ try {
 			'uri' => 'https://example.com/run/import',
 			// The timeout option is in seconds and defaults to 3 if unspecified.
 			'timeout' => 3,
+			// the token must match 'upload.token' config in xhgui
+			'token' => 'token',
 		),
 
 		// For MongoDB

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -43,6 +43,9 @@ final class SaverFactory
                 if (isset($config['save.handler.upload.timeout']) && !isset($config['save.handler.upload']['timeout'])) {
                     $config['save.handler.upload.timeout'] = $config['save.handler.upload']['timeout'];
                 }
+                if (!empty($config['save.handler.upload']['token'])) {
+                    $config['save.handler.upload.uri'] .= '?token=' . $config['save.handler.upload']['token'];
+                }
                 break;
             case Profiler::SAVER_MONGODB:
                 if (isset($config['save.handler.mongodb']['dsn']) && !isset($config['db.host'])) {


### PR DESCRIPTION
```php
		'save.handler.upload' => array(
			'uri' => 'https://example.com/run/import',
			// The timeout option is in seconds and defaults to 3 if unspecified.
			'timeout' => 3,
			// the token must match 'upload.token' config in xhgui
			'token' => 'token',
		),
```

Accompanying change in xhgui:
- https://github.com/perftools/xhgui/pull/289