### PR TITLE
Run session_write_close on shutdown handler

### DIFF
--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -148,6 +148,11 @@ class Profiler
         // flush() asks PHP to send any data remaining in the output buffers. This is normally done when the script completes, but
         // since we're delaying that a bit by dealing with the xhprof stuff, we'll do it now to avoid making the user wait.
         ignore_user_abort(true);
+
+        if (function_exists('session_write_close')) {
+            session_write_close();
+        }
+
         flush();
 
         try {


### PR DESCRIPTION
xhgui-collector has session_write_close, fastcgi_finish_request, in the header:
- https://github.com/perftools/xhgui-collector/blob/1.8.0/external/header.php#L148-L164

refs:
- https://github.com/perftools/xhgui-collector/pull/15
