### PR TITLE
Add fastcgi_finish_request to shutDown handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ try {
 }
 ```
 
+If you need to disable profiler doing `flush`, `session_write_close` and
+`fastcgi_finish_request` at the end of profiling, pass `false` to register
+shutdown handler:
+
+```php
+$profiler->registerShutdownHandler(false);
+```
+
 ## Advanced Usage
 
 You might want to control capture and sending yourself,

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -155,6 +155,10 @@ class Profiler
 
         flush();
 
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        }
+
         try {
             $this->stop();
         } catch (Exception $e) {


### PR DESCRIPTION
xhgui-collector has fastcgi_finish_request, in the header:
- https://github.com/perftools/xhgui-collector/blob/1.8.0/external/header.php#L162-L164

refs:
- https://github.com/perftools/xhgui-collector/pull/13

but this needs to be configurable, as applications may rely on ability to send output in output handler:
- https://github.com/perftools/xhgui-collector/pull/23