### PR TITLE
Add xdebug tracing support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"ext-mongodb": "mongodb extension (PHP>=5.4)",
 		"ext-tideways": "Use tideways to profile",
 		"ext-uprofiler": "Use uprofiler to profile",
+		"ext-xdebug": "Use xdebug to profile",
 		"ext-xhprof": "Use xhprof to profile",
 		"alcaeus/mongo-php-adapter": "Adapter to provide ext-mongo interface on top of mongo-php-libary (PHP>=5.6)"
 	},

--- a/src/Profilers/XdebugProfiler.php
+++ b/src/Profilers/XdebugProfiler.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Xhgui\Profiler\Profilers;
+
+/**
+ * @see https://xdebug.org/docs/execution_trace
+ */
+class XdebugProfiler extends AbstractProfiler
+{
+    const EXTENSION_NAME = 'xdebug';
+
+    public function isSupported()
+    {
+        return extension_loaded(self::EXTENSION_NAME);
+    }
+
+    public function enable($flags = array(), $options = array())
+    {
+        $traceFile = xdebug_start_trace();
+//        uprofiler_enable($this->combineFlags($flags, $this->getProfileFlagMap()), $options);
+    }
+
+    public function disable()
+    {
+        $traceFile = xdebug_stop_trace();
+
+        return $this->readTrace($traceFile);
+    }
+
+    private function readTrace($traceFile)
+    {
+        return file_get_contents($traceFile);
+    }
+}

--- a/tests/Profiler/XdebugProfilerTest.php
+++ b/tests/Profiler/XdebugProfilerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Xhgui\Profiler\Test\Profiler;
+
+use Xhgui\Profiler\Profilers\XdebugProfiler;
+use Xhgui\Profiler\Test\TestCase;
+
+/**
+ * @requires extension xdebug
+ */
+class XdebugProfilerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->profiler = new XdebugProfiler();
+    }
+
+    public function testDefaults()
+    {
+        $data = $this->runProfiler();
+        $this->assertCount(13, $data);
+    }
+}


### PR DESCRIPTION
This uses xdebug [execution_trace]:

[execution_trace]: https://xdebug.org/docs/execution_trace

```
TRACE START [2020-07-30 05:48:57]
    2.7023    9969960                           -> Xhgui\Profiler\Profilers\XdebugProfiler->disable() /Users/glen/scm/xhgui/php-profiler/tests/TestCase.php:25
    4.1043    9969960                             -> xdebug_stop_trace() /Users/glen/scm/xhgui/php-profiler/src/Profilers/XdebugProfiler.php:27
    4.1044    9970016
TRACE END   [2020-07-30 05:48:58]
```

Probably not much usable, as seems not possible to programmatically to start profiling:
- https://stackoverflow.com/questions/8077993/can-i-manually-say-on-xdebug-profiler-to-start-profiling-in-specific-place

v3 docs:
- https://3.xdebug.org/docs/trace#functions