### PR TITLE
Cleanup interface, use start() to activate profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ try {
 
     // The profiler itself checks whether it should be enabled
     // for request (executes lambda function from config)
-    $profiler->enable();
-
-    // shutdown handler collects and stores the data.
-    $profiler->registerShutdownHandler();
+    $profiler->start();
 } catch (Exception $e){
     // throw away or log error about profiling instantiation failure
 }
@@ -68,7 +65,7 @@ If you need to disable profiler doing `flush`, `session_write_close` and
 shutdown handler:
 
 ```php
-$profiler->registerShutdownHandler(false);
+$profiler->start(false);
 ```
 
 ## Advanced Usage

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -136,13 +136,12 @@ class Profiler
      *
      * @see Profiler::shutDown
      */
-    public function registerShutdownHandler($flush = true)
+    private function registerShutdownHandler()
     {
         // do not register shutdown function if the profiler isn't running
         if (!$this->running) {
             return;
         }
-        $this->flush = $flush;
 
         register_shutdown_function(array($this, 'shutDown'));
     }
@@ -231,9 +230,13 @@ class Profiler
     /**
      * This is an alias for method "enable"
      */
-    public function start()
+    public function start($flush = true)
     {
         $this->enable();
+
+        $this->flush = $flush;
+        // shutdown handler collects and stores the data.
+        $this->registerShutdownHandler();
     }
 
     /**

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -83,6 +83,11 @@ class Profiler
             throw new RuntimeException('Unable to create profiler: No suitable profiler found');
         }
 
+        $saver = $this->getSaver();
+        if (!$saver) {
+            throw new RuntimeException('Unable to create saver');
+        }
+
         if ($flags === null) {
             $flags = $this->config['profiler.flags'];
         }
@@ -260,7 +265,14 @@ class Profiler
             return array();
         }
 
-        $profile = new ProfilingData($this->profiler->disable(), $this->config);
+        $profiler = $this->getProfiler();
+        if (!$profiler) {
+            // error for unable to create profiler already thrown in enable() method
+            // but this can also happen if methods are called out of sync
+            throw new RuntimeException('Unable to create profiler: No suitable profiler found');
+        }
+
+        $profile = new ProfilingData($profiler->disable(), $this->config);
         $this->running = false;
 
         return $profile->getProfilingData();
@@ -279,6 +291,8 @@ class Profiler
 
         $saver = $this->getSaver();
         if (!$saver) {
+            // error for unable to create saver already thrown in enable() method
+            // but this can also happen if methods are called out of sync
             throw new RuntimeException('Unable to create profiler: Unable to create saver');
         }
 


### PR DESCRIPTION
Change public API requiring only to call `$profiler->start()` to start profiling and submit on request shutdown:


```diff
+        $profiler = new Profiler($this->getProfilerConfig());
+
         try {
-            $profiler = new Profiler($this->getProfilerConfig());
+            $profiler->start();
         } catch (Throwable $e) {
             $this->debug($e->getMessage(), ['exception' => $e]);
-
-            return;
         }
-
-        $profiler->enable();
-        $profiler->registerShutdownHandler();
```


From https://github.com/perftools/php-profiler/issues/15#issuecomment-665955861:

> perhaps the `enable()`/`disable()` should always work, i.e not depend on `profiler.enable`?
> 
> so that you can just profile code-points in your applications, i.e the advanced usage:
> - https://github.com/perftools/php-profiler#advanced-usage
> 
> and make ease of unit testing (no hidden dependencies):
> - https://github.com/perftools/php-profiler/pull/30
> 
> and the `profiler.enable` would be used for auto-mode:
> - https://github.com/perftools/php-profiler#create-profiler
> 
> 
> ```php
>     $profiler = new \Xhgui\Profiler\Profiler($config);
> 
>     // The profiler itself checks whether it should be enabled
>     // for request (executes lambda function from config)
>     $profiler->start();
> 
>     // shutdown handler collects and stores the data.
>     $profiler->registerShutdownHandler();
> ```
> 
> and I wonder is the separate `registerShutdownHandler` call needed? move that logic to `start` method?