### PR TITLE
Add stack saver

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,34 @@ Example config:
 
 To import a saved files, use XHGui's provided `external/import.php` script.
 
+### Stack saver
+
+Allows saving to multiple handlers.
+Useful to fall back to file saver if the upload saver failed.
+
+Example config:
+
+```php
+    'save.handler' => \Xhgui\Profiler\Profiler::SAVER_STACK,
+    'save.handler.stack' => array(
+        'savers' => array(
+            \Xhgui\Profiler\Profiler::SAVER_UPLOAD,
+            \Xhgui\Profiler\Profiler::SAVER_FILE,
+        ),
+        // if saveAll=false, break the chain on successful save
+        'saveAll' => false,
+    ),
+    // subhandler specific configs
+    'save.handler.file' => array(
+        'filename' => '/tmp/xhgui.data.jsonl',
+    ),
+    'save.handler.upload' => array(
+        'uri' => 'https://example.com/run/import',
+        'timeout' => 3,
+        'token' => 'token',
+    ),
+```
+
 ### MongoDB Saver
 
 For saving directly to MongoDB you would need [ext-mongo] for PHP 5

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -13,6 +13,7 @@ class Profiler
     const SAVER_FILE = 'file';
     const SAVER_MONGODB = 'mongodb';
     const SAVER_PDO = 'pdo';
+    const SAVER_STACK = 'stack';
 
     const PROFILER_TIDEWAYS = 'tideways';
     const PROFILER_TIDEWAYS_XHPROF = 'tideways_xhprof';

--- a/src/Saver/StackSaver.php
+++ b/src/Saver/StackSaver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Xhgui\Profiler\Saver;
+
+use Exception;
+
+/**
+ * Save to stack of savers
+ */
+class StackSaver implements SaverInterface
+{
+    /** @var array */
+    private $savers;
+    /** @var bool */
+    private $saveAll;
+
+    public function __construct(array $savers, $saveAll = false)
+    {
+        $this->savers = $savers;
+        $this->saveAll = (bool)$saveAll;
+    }
+
+    public function isSupported()
+    {
+        return true;
+    }
+
+    public function save(array $data)
+    {
+        $result = false;
+        foreach ($this->savers as $saver) {
+            try {
+                if (!$saver->save($data)) {
+                    continue;
+                }
+                $result = true;
+            } catch (Exception $e) {
+                continue;
+            }
+
+            // if not save all, then break on first successful save
+            if (!$this->saveAll) {
+                break;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -23,6 +23,7 @@ final class SaverFactory
                 ), isset($config['save.handler.file']) ? $config['save.handler.file'] : array());
                 $saver = new Saver\FileSaver($saverConfig['filename']);
                 break;
+
             case Profiler::SAVER_UPLOAD:
                 $saverConfig = array_merge(array(
                     'uri' => null,
@@ -30,6 +31,19 @@ final class SaverFactory
                     'timeout' => 3,
                 ), isset($config['save.handler.upload']) ? $config['save.handler.upload'] : array());
                 $saver = new Saver\UploadSaver($saverConfig['uri'], $saverConfig['token'], $saverConfig['timeout']);
+                break;
+
+            case Profiler::SAVER_STACK:
+                $saverConfig = array_merge(array(
+                    'savers' => array(),
+                    'saveAll' => false,
+                ), isset($config['save.handler.stack']) ? $config['save.handler.stack'] : array());
+
+                $savers = array();
+                foreach ($saverConfig['savers'] as $saver) {
+                    $savers[] = self::create($saver, $config);
+                }
+                $saver = new Saver\StackSaver($savers, $saverConfig['saveAll']);
                 break;
             default:
                 // create via xhgui-collector

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -41,7 +41,10 @@ final class SaverFactory
 
                 $savers = array();
                 foreach ($saverConfig['savers'] as $saver) {
-                    $savers[] = self::create($saver, $config);
+                    $instance = self::create($saver, $config);
+                    if ($instance) {
+                        $savers[] = $instance;
+                    }
                 }
                 $saver = new Saver\StackSaver($savers, $saverConfig['saveAll']);
                 break;


### PR DESCRIPTION

### Stack saver

Allows saving to multiple handlers.
Useful to fall back to file saver if the upload saver failed.

Example config:

```php
    'save.handler' => \Xhgui\Profiler\Profiler::SAVER_STACK,
    'save.handler.stack' => array(
        'savers' => array(
            \Xhgui\Profiler\Profiler::SAVER_UPLOAD,
            \Xhgui\Profiler\Profiler::SAVER_FILE,
        ),
        // if saveAll=false, break the chain on successful save
        'saveAll' => false,
    ),
    // subhandler specific configs
    'save.handler.file' => array(
        'filename' => '/tmp/xhgui.data.jsonl',
    ),
    'save.handler.upload' => array(
        'uri' => 'https://example.com/run/import',
        'timeout' => 3,
        'token' => 'token',
    ),
```