### PR TITLE
Add alcaeus/mongo-php-adapter to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 		"ext-json": "*"
 	},
 	"require-dev": {
+		"alcaeus/mongo-php-adapter": "^1.1",
 		"perftools/xhgui-collector": "^1.8"
 	},
 	"conflict": {


### PR DESCRIPTION
This was mistakenly removed in b34407b6ae8499662d178a14bf94dd51f3a433af due poor rebasing.