### PR TITLE
Rename upload saver "uri" option to "url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Example config:
     // Saving profile data by upload is only recommended with HTTPS
     // endpoints that have IP whitelists applied.
     'save.handler.upload' => array(
-        'uri' => 'https://example.com/run/import',
+        'url' => 'https://example.com/run/import',
         // The timeout option is in seconds and defaults to 3 if unspecified.
         'timeout' => 3,
         // the token must match 'upload.token' config in XHGui
@@ -165,7 +165,7 @@ Example config:
         'filename' => '/tmp/xhgui.data.jsonl',
     ),
     'save.handler.upload' => array(
-        'uri' => 'https://example.com/run/import',
+        'url' => 'https://example.com/run/import',
         'timeout' => 3,
         'token' => 'token',
     ),

--- a/examples/autoload.php
+++ b/examples/autoload.php
@@ -37,7 +37,7 @@ try {
         // endpoints that have IP whitelists applied.
         // https://github.com/perftools/php-profiler#upload-saver
         'save.handler.upload' => array(
-            'uri' => 'https://example.com/run/import',
+            'url' => 'https://example.com/run/import',
             // The timeout option is in seconds and defaults to 3 if unspecified.
             'timeout' => 3,
             // the token must match 'upload.token' config in XHGui

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -28,13 +28,14 @@ final class SaverFactory
 
             case Profiler::SAVER_UPLOAD:
                 $defaultConfig = array(
-                    'uri' => null,
+                    'uri' => null, // @deprecated
+                    'url' => null,
                     'token' => null,
                     'timeout' => 3,
                 );
                 $userConfig = isset($config['save.handler.upload']) && is_array($config['save.handler.upload']) ? $config['save.handler.upload'] : array();
                 $saverConfig = array_merge($defaultConfig, $userConfig);
-                $saver = new Saver\UploadSaver($saverConfig['uri'], $saverConfig['token'], $saverConfig['timeout']);
+                $saver = new Saver\UploadSaver($saverConfig['url'] ?: $saverConfig['uri'], $saverConfig['token'], $saverConfig['timeout']);
                 break;
 
             case Profiler::SAVER_STACK:


### PR DESCRIPTION
Go with the flow, keep it as simple "url", no need to be a pedant about "uri"/"url".

Fallback to `uri` remains, so this is not a breaking change.