### PR TITLE
Add example for profiler.enable with xdebug profiling enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ requests with the `/blog` URL path:
     },
 ```
 
-Here's an example to disable profiling if xdebug session is enalbed:
+Here's an example to disable profiling if xdebug session is enabled:
 
 ```php
     'profiler.enable' => function() {

--- a/README.md
+++ b/README.md
@@ -268,6 +268,18 @@ requests with the `/blog` URL path:
     },
 ```
 
+Here's an example to disable profiling if xdebug session is enalbed:
+
+```php
+    'profiler.enable' => function() {
+        if (function_exists('xdebug_is_enabled') && xdebug_is_enabled()) {
+            return false;
+        }
+
+        return true;
+    },
+```
+
 In contrast, the following example instructs to profile _every_
 request:
 


### PR DESCRIPTION
This adds an example to Detect XDebug triggers and skip profiling:
- https://github.com/perftools/xhgui/issues/104

See https://github.com/perftools/xhgui/issues/104#issuecomment-54754662