### PR TITLE
Encode mongodb keys (strip out dot)

### DIFF
--- a/src/Saver/MongoSaver.php
+++ b/src/Saver/MongoSaver.php
@@ -20,7 +20,9 @@ class MongoSaver extends AbstractSaver
 
     public function save(array $data)
     {
-        $data['profile'] = $this->encodeProfile($data['profile']);
+        if (isset($data['profile'])) {
+            $data['profile'] = $this->encodeProfile($data['profile']);
+        }
 
         $result = parent::save($data);
 

--- a/src/Saver/MongoSaver.php
+++ b/src/Saver/MongoSaver.php
@@ -20,8 +20,33 @@ class MongoSaver extends AbstractSaver
 
     public function save(array $data)
     {
+        $data['profile'] = $this->encodeProfile($data['profile']);
+
         $result = parent::save($data);
 
         return !empty($result);
+    }
+
+    /**
+     * MongoDB can't save keys with values containing a dot:
+     *
+     *   InvalidArgumentException: invalid document for insert: keys cannot contain ".":
+     *   "Zend_Controller_Dispatcher_Standard::loadClass==>load::controllers/ArticleController.php"
+     *
+     * Replace the dots with underscrore in keys.
+     *
+     * @link https://github.com/perftools/xhgui/issues/209
+     */
+    private function encodeProfile(array $profile)
+    {
+        $results = array();
+        foreach ($profile as $k => $v) {
+            if (strpos($k, '.') !== false) {
+                $k = str_replace('.', '_', $k);
+            }
+            $results[$k] = $v;
+        }
+
+        return $results;
     }
 }


### PR DESCRIPTION
As the https://github.com/perftools/xhgui-collector package will no longer be updated,
do the change in https://github.com/perftools/php-profiler.

This duplicates the same fix in xhgui itself:
- https://github.com/perftools/xhgui/pull/352

Do note that Users are encouraged to switch to file or upload savers instead of using this saver.

Fixes https://github.com/perftools/php-profiler/issues/60