### PR TITLE
Add UploadSaver error explanation if available

### DIFF
--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -61,18 +61,21 @@ class UploadSaver implements SaverInterface
             CURLOPT_TIMEOUT => $this->timeout,
         ));
         if (!$res) {
-            throw new ProfilerException('Failed to set cURL options');
+            $error = curl_errno($ch) ? curl_error($ch) : '';
+            throw new ProfilerException('Failed to set cURL options'.($error ? ': '.$error : ''));
         }
 
         $result = curl_exec($ch);
         if ($result === false) {
-            throw new ProfilerException('Failed to submit data');
+            $error = curl_errno($ch) ? curl_error($ch) : '';
+            throw new ProfilerException('Failed to submit data'.($error ? ': '.$error : ''));
         }
         curl_close($ch);
 
         $response = json_decode($result, true);
         if (!$response) {
-            throw new ProfilerException('Failed to decode response');
+            $error = json_last_error() ? (PHP_VERSION_ID >= 50500 ? json_last_error_msg() : 'Error '.json_last_error()) : '';
+            throw new ProfilerException('Failed to decode response'.($error ? ': '.$error : ''));
         }
 
         if (isset($response['error']) && $response['error']) {


### PR DESCRIPTION
I've got error in the log `Failed to submit data` but what exactly happen is not clear. So I've decided to add error explanation in exceptions.

PHP bumped to 5.5.0 because `json_last_error_msg` was introduced in PHP 5.5.