### PR TITLE
Fix processing REQUEST_TIME_FLOAT value

### DIFF
--- a/src/ProfilingData.php
+++ b/src/ProfilingData.php
@@ -25,7 +25,7 @@ class ProfilingData
     {
         $url = $this->getUrl();
 
-        $requestTimeFloat = explode('.', $_SERVER['REQUEST_TIME_FLOAT']);
+        $requestTimeFloat = explode('.', sprintf('%.6F', $_SERVER['REQUEST_TIME_FLOAT']));
         if (!isset($requestTimeFloat[1])) {
             $requestTimeFloat[1] = 0;
         }


### PR DESCRIPTION
Avoid using float when parsing `REQUEST_TIME_FLOAT`,
as it may be formatted with a comma, depending on the locale.

Otherwise, get this notice when passing `1649168503,0729` to date:
> PHP Notice:  A non well formed numeric value encountered