### PR TITLE
Feature: Add config.php file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ shutdown handler:
 $profiler->start(false);
 ```
 
+## Using config file
+
+You can create `config/config.php` and load config from there:
+
+1. copy `config/config.default.php` to `config/config.php`
+2. use `Config::create()` to `new Profiler`
+
+```php
+// Config::create() will load config/config.default.php
+// and then merge with config/config.php (if it exists).
+$config = \Xhgui\Profiler\Config::create();
+$profiler = new \Xhgui\Profiler\Profiler($config);
+```
+
 ## Advanced Usage
 
 You might want to control capture and sending yourself,

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Default configuration for PHP Profiler.
+ *
+ * To change these, create a file called `config.php` file in the same directory
+ * and return an array from there with your overriding settings.
+ */
+
+use Xhgui\Profiler\Profiler;
+use Xhgui\Profiler\ProfilingFlags;
+
+return array(
+    'save.handler' => Profiler::SAVER_STACK,
+    'save.handler.stack' => array(
+        'savers' => array(
+            Profiler::SAVER_UPLOAD,
+            Profiler::SAVER_FILE,
+        ),
+        'saveAll' => false,
+    ),
+    'save.handler.file' => array(
+        'filename' => sys_get_temp_dir() . '/xhgui.data.jsonl',
+    ),
+    'profiler.enable' => function () {
+        return true;
+    },
+    'profiler.flags' => array(
+        ProfilingFlags::CPU,
+        ProfilingFlags::MEMORY,
+        ProfilingFlags::NO_BUILTINS,
+        ProfilingFlags::NO_SPANS,
+    ),
+    'profiler.options' => array(),
+    'profiler.exclude-env' => array(),
+    'profiler.simple_url' => function ($url) {
+        return preg_replace('/=\d+/', '', $url);
+    },
+    'profiler.replace_url' => null,
+);

--- a/src/Config.php
+++ b/src/Config.php
@@ -35,6 +35,9 @@ class Config implements ArrayAccess
             throw new ProfilerException("File does not exist: $filename");
         }
         $config = require $filename;
+        if ($config === 1) {
+            throw new ProfilerException("Config did not return an array: $filename");
+        }
         $this->merge($config);
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,6 +27,22 @@ class Config implements ArrayAccess
     }
 
     /**
+     * Create config from defaults, and merge config/config.php if the file exists
+     *
+     * @return Config
+     */
+    public static function create()
+    {
+        $configDir = dirname(__DIR__) . '/config';
+        $config = new self();
+        if (file_exists($file = $configDir . '/config.php')) {
+            $config->load($file);
+        }
+
+        return $config;
+    }
+
+    /**
      * Load a config file, merge with the currently loaded configuration.
      */
     public function load($filename)

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,11 +8,11 @@ use Xhgui\Profiler\Exception\ProfilerException;
 class Config implements ArrayAccess
 {
     /** @var array */
-    private $config;
+    private $config = array();
 
     public function __construct(array $config = array())
     {
-        $this->config = $this->getDefaultConfig();
+        $this->loadDefaultConfig();
         if ($config) {
             $this->merge($config);
         }
@@ -66,38 +66,8 @@ class Config implements ArrayAccess
         unset($this->config[$offset]);
     }
 
-    /**
-     * @return array
-     */
-    private function getDefaultConfig()
+    private function loadDefaultConfig()
     {
-        return array(
-            'save.handler' => Profiler::SAVER_STACK,
-            'save.handler.stack' => array(
-                'savers' => array(
-                    Profiler::SAVER_UPLOAD,
-                    Profiler::SAVER_FILE,
-                ),
-                'saveAll' => false,
-            ),
-            'save.handler.file' => array(
-                'filename' => sys_get_temp_dir() . '/xhgui.data.jsonl',
-            ),
-            'profiler.enable' => function () {
-                return true;
-            },
-            'profiler.flags' => array(
-                ProfilingFlags::CPU,
-                ProfilingFlags::MEMORY,
-                ProfilingFlags::NO_BUILTINS,
-                ProfilingFlags::NO_SPANS,
-            ),
-            'profiler.options' => array(),
-            'profiler.exclude-env' => array(),
-            'profiler.simple_url' => function ($url) {
-                return preg_replace('/=\d+/', '', $url);
-            },
-            'profiler.replace_url' => null,
-        );
+        $this->load(__DIR__ . '/../config/config.default.php');
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,6 +3,7 @@
 namespace Xhgui\Profiler;
 
 use ArrayAccess;
+use Xhgui\Profiler\Exception\ProfilerException;
 
 class Config implements ArrayAccess
 {
@@ -23,6 +24,18 @@ class Config implements ArrayAccess
     public function toArray()
     {
         return $this->config;
+    }
+
+    /**
+     * Load a config file, merge with the currently loaded configuration.
+     */
+    public function load($filename)
+    {
+        if (!file_exists($filename)) {
+            throw new ProfilerException("File does not exist: $filename");
+        }
+        $config = require $filename;
+        $this->merge($config);
     }
 
     private function merge(array $config)

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -19,4 +19,14 @@ class ConfigTest extends TestCase
         $config->load(__DIR__ . '/Resources/config_saver.php');
         $this->assertEquals(Profiler::SAVER_UPLOAD, $config['save.handler']);
     }
+
+    /**
+     * @expectedException \Xhgui\Profiler\Exception\ProfilerException
+     * @expectedExceptionMessage Config did not return an array
+     */
+    public function testBadConfig()
+    {
+        $config = new Config();
+        $config->load(__DIR__ . '/Resources/config_bad_return.php');
+    }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -20,6 +20,12 @@ class ConfigTest extends TestCase
         $this->assertEquals(Profiler::SAVER_UPLOAD, $config['save.handler']);
     }
 
+    public function testFromFile()
+    {
+        $config = Config::create();
+        $this->assertEquals(Profiler::SAVER_STACK, $config['save.handler']);
+    }
+
     /**
      * @expectedException \Xhgui\Profiler\Exception\ProfilerException
      * @expectedExceptionMessage Config did not return an array

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,4 +12,11 @@ class ConfigTest extends TestCase
         $config = new Config();
         $this->assertEquals(Profiler::SAVER_STACK, $config['save.handler']);
     }
+
+    public function testLoadConfig()
+    {
+        $config = new Config();
+        $config->load(__DIR__ . '/Resources/config_saver.php');
+        $this->assertEquals(Profiler::SAVER_UPLOAD, $config['save.handler']);
+    }
 }

--- a/tests/Resources/config_bad_return.php
+++ b/tests/Resources/config_bad_return.php
@@ -1,0 +1,7 @@
+<?php
+
+use Xhgui\Profiler\Profiler;
+
+$config = array(
+    'save.handler' => Profiler::SAVER_UPLOAD,
+);

--- a/tests/Resources/config_saver.php
+++ b/tests/Resources/config_saver.php
@@ -1,0 +1,7 @@
+<?php
+
+use Xhgui\Profiler\Profiler;
+
+return array(
+    'save.handler' => Profiler::SAVER_UPLOAD,
+);


### PR DESCRIPTION
Adds support for using config files

```php
// Config::create() will load config/config.default.php
// and then merge with config/config.php (if it exists).
$config = \Xhgui\Profiler\Config::create();
$profiler = new \Xhgui\Profiler\Profiler($config);
```


This is preparation to add support for import.php cli tool:
- https://github.com/perftools/xhgui/issues/478#issuecomment-1139393478