### PR TITLE
Encoding malformed characters

### DIFF
--- a/src/Saver/FileSaver.php
+++ b/src/Saver/FileSaver.php
@@ -19,7 +19,11 @@ final class FileSaver implements SaverInterface
 
     public function save(array $data)
     {
-        $json = json_encode($data);
+        $json = json_encode($data, PHP_VERSION_ID >= 70200 ? JSON_INVALID_UTF8_IGNORE : 0);
+
+        if ($json === false) {
+            return false;
+        }
 
         return file_put_contents($this->file, $json . PHP_EOL, FILE_APPEND);
     }

--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -28,7 +28,12 @@ final class UploadSaver implements SaverInterface
 
     public function save(array $data)
     {
-        $json = json_encode($data);
+        $json = json_encode($data, PHP_VERSION_ID >= 70200 ? JSON_INVALID_UTF8_IGNORE : 0);
+
+        if ($json === false) {
+            return false;
+        }
+
         $this->submit($this->url, $json);
 
         return true;


### PR DESCRIPTION
*No collected data available*

While profiling an application, malformed data were sent to a saver (both, Upload and File) that called `json_encode` with the provided data.  
That resulted into an encoding error, returning false that was casted into an empty string.  

Because of that, no collected data was available at the end of the request.

The proposed change uses [JSON_INVALID_UTF8_IGNORE](https://www.php.net/manual/en/json.constants.php#constant.json-invalid-utf8-ignore) constant which removes all invalid characters, making the encoding possible.

The constant is available since PHP 7.2, that is why a 'check' is made before the encoding. If the PHP has the constant, it will use it.

---
Even though the change removes a word/key from the resulted output, the change does not have any undesirable changes because the previous (current) behavior does not generate the output at all.