### PR TITLE
Add Option to Disable SSL Verification for cURL Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Example config:
         // the token must match 'upload.token' config in XHGui
         'token' => 'token',
         // verify option to disable ssl verification, defaults to true if unspecified.
-        'verify' => false,
+        'verify' => true,
     ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Example config:
         'timeout' => 3,
         // the token must match 'upload.token' config in XHGui
         'token' => 'token',
+        // verify option to disable ssl verification, defaults to true if unspecified.
+        'verify' => false,
     ),
 ```
 

--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -10,8 +10,10 @@ final class UploadSaver implements SaverInterface
     private $url;
     /** @var int */
     private $timeout;
+    /** @var bool */
+    private $verify;
 
-    public function __construct($url, $token, $timeout)
+    public function __construct($url, $token, $timeout, $verify)
     {
         $this->url = $url;
         if ($token) {
@@ -19,6 +21,7 @@ final class UploadSaver implements SaverInterface
         }
 
         $this->timeout = $timeout;
+        $this->verify = $verify;
     }
 
     public function isSupported()
@@ -64,6 +67,7 @@ final class UploadSaver implements SaverInterface
             CURLOPT_FOLLOWLOCATION => 1,
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_TIMEOUT => $this->timeout,
+            CURLOPT_SSL_VERIFYPEER => $this->verify,
         ));
         if (!$res) {
             $error = curl_errno($ch) ? curl_error($ch) : '';

--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -21,7 +21,7 @@ final class UploadSaver implements SaverInterface
         }
 
         $this->timeout = $timeout;
-        $this->verify = $verify;
+        $this->verify = is_bool($verify) ? $verify : true;
     }
 
     public function isSupported()

--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -21,7 +21,7 @@ final class UploadSaver implements SaverInterface
         }
 
         $this->timeout = $timeout;
-        $this->verify = is_bool($verify) ? $verify : true;
+        $this->verify = $verify;
     }
 
     public function isSupported()

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -39,7 +39,12 @@ final class SaverFactory
                 );
                 $userConfig = isset($config['save.handler.upload']) && is_array($config['save.handler.upload']) ? $config['save.handler.upload'] : array();
                 $saverConfig = array_merge($defaultConfig, $userConfig);
-                $saver = new Saver\UploadSaver($saverConfig['url'] ?: $saverConfig['uri'], $saverConfig['token'], $saverConfig['timeout']);
+                $saver = new Saver\UploadSaver(
+                    $saverConfig['url'] ?: $saverConfig['uri'],
+                    $saverConfig['token'],
+                    $saverConfig['timeout'],
+                    $saverConfig['verify']
+                );
                 break;
 
             case Profiler::SAVER_STACK:

--- a/src/SaverFactory.php
+++ b/src/SaverFactory.php
@@ -35,6 +35,7 @@ final class SaverFactory
                     'url' => null,
                     'token' => null,
                     'timeout' => 3,
+                    'verify' => true,
                 );
                 $userConfig = isset($config['save.handler.upload']) && is_array($config['save.handler.upload']) ? $config['save.handler.upload'] : array();
                 $saverConfig = array_merge($defaultConfig, $userConfig);


### PR DESCRIPTION
**Description:**
This PR introduces a new feature that allows users to disable SSL verification for cURL requests. This can be useful for testing in development environments or interacting with endpoints using self-signed certificates.

**Changes:**
- Added a new configuration option `verify` (default: true).
- Updated cURL `curl_setopt_array` to include the new setting `CURLOPT_SSL_VERIFYPEER`

**Checklist:**
- [x] Feature implemented
- [x] Documentation updated

**Note:**
_Disabling SSL verification may expose requests to potential security risks. Use this option only in trusted environments._