### PR TITLE
Exclude all ENV variables with new configuration option

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -32,7 +32,7 @@ return array(
     ),
     'profiler.options' => array(),
     'profiler.exclude-env' => array(),
-    'profiler.is-exclude-all-env' => false,
+    'profiler.exclude-all-env' => false,
     'profiler.simple_url' => function ($url) {
         return preg_replace('/=\d+/', '', $url);
     },

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -32,6 +32,7 @@ return array(
     ),
     'profiler.options' => array(),
     'profiler.exclude-env' => array(),
+    'profiler.is-exclude-all-env' => false,
     'profiler.simple_url' => function ($url) {
         return preg_replace('/=\d+/', '', $url);
     },

--- a/examples/autoload.php
+++ b/examples/autoload.php
@@ -118,6 +118,11 @@ try {
         'profiler.replace_url' => function ($url) {
             return str_replace('token', '', $url);
         },
+        /**
+         * If true, excludes all environment variables from profiling data.
+         * @return bool
+         */
+        'profiler.exclude-all-env' => false,
     );
 
     /**

--- a/src/ProfilingData.php
+++ b/src/ProfilingData.php
@@ -14,12 +14,12 @@ final class ProfilingData
     /** @var callable|null */
     private $replaceUrl;
     /** @var bool */
-    private $isExcludeAllEnv;
+    private $excludeAllEnv;
 
     public function __construct(Config $config)
     {
         $this->excludeEnv = isset($config['profiler.exclude-env']) ? (array)$config['profiler.exclude-env'] : array();
-        $this->isExcludeAllEnv = isset($config['profiler.is-exclude-all-env']) ? $config['profiler.is-exclude-all-env'] : false;
+        $this->excludeAllEnv = isset($config['profiler.exclude-all-env']) ? $config['profiler.exclude-all-env'] : false;
         $this->simpleUrl = isset($config['profiler.simple_url']) ? $config['profiler.simple_url'] : null;
         $this->replaceUrl = isset($config['profiler.replace_url']) ? $config['profiler.replace_url'] : null;
     }
@@ -82,7 +82,7 @@ final class ProfilingData
      */
     private function getEnvironment(array $env)
     {
-        if($this->isExcludeAllEnv) {
+        if ($this->excludeAllEnv) {
             return array();
         }
 

--- a/src/ProfilingData.php
+++ b/src/ProfilingData.php
@@ -13,10 +13,13 @@ final class ProfilingData
     private $simpleUrl;
     /** @var callable|null */
     private $replaceUrl;
+    /** @var bool */
+    private $isExcludeAllEnv;
 
     public function __construct(Config $config)
     {
         $this->excludeEnv = isset($config['profiler.exclude-env']) ? (array)$config['profiler.exclude-env'] : array();
+        $this->isExcludeAllEnv = isset($config['profiler.is-exclude-all-env']) ? $config['profiler.is-exclude-all-env'] : false;
         $this->simpleUrl = isset($config['profiler.simple_url']) ? $config['profiler.simple_url'] : null;
         $this->replaceUrl = isset($config['profiler.replace_url']) ? $config['profiler.replace_url'] : null;
     }
@@ -79,6 +82,10 @@ final class ProfilingData
      */
     private function getEnvironment(array $env)
     {
+        if($this->isExcludeAllEnv) {
+            return array();
+        }
+
         foreach ($this->excludeEnv as $key) {
             unset($env[$key]);
         }

--- a/tests/ProfilingDataTest.php
+++ b/tests/ProfilingDataTest.php
@@ -12,13 +12,12 @@ class ProfilingDataTest extends TestCase
         $_ENV['TEST_EXCLUDE_ENV'] = 'TEST';
 
         $config = new Config([
-            'profiler.is-exclude-all-env' => true,
+            'profiler.exclude-all-env' => true,
         ]);
         $profilingData = new ProfilingData($config);
 
         $profile = ['example' => 'data'];
         $result = $profilingData->getProfilingData($profile);
-
 
         $this->assertEmpty($result['meta']['env']);
     }
@@ -28,7 +27,7 @@ class ProfilingDataTest extends TestCase
         $_ENV['TEST_EXCLUDE_ENV'] = 'TEST';
 
         $config = new Config([
-            'profiler.is-exclude-all-env' => false,
+            'profiler.exclude-all-env' => false,
         ]);
         $profilingData = new ProfilingData($config);
 
@@ -37,6 +36,4 @@ class ProfilingDataTest extends TestCase
 
         $this->assertEquals('TEST', $result['meta']['env']['TEST_EXCLUDE_ENV']);
     }
-
-
 }

--- a/tests/ProfilingDataTest.php
+++ b/tests/ProfilingDataTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Xhgui\Profiler\Test;
+
+use Xhgui\Profiler\Config;
+use Xhgui\Profiler\ProfilingData;
+
+class ProfilingDataTest extends TestCase
+{
+    public function testExcludeAllEnv()
+    {
+        $config = new Config([
+            'profiler.is-exclude-all-env' => true
+        ]);
+        $profilingData = new ProfilingData($config);
+
+        $profile = ['example' => 'data'];
+        $result = $profilingData->getProfilingData($profile);
+
+
+        $this->assertEmpty($result['meta']['env']);
+    }
+
+
+}

--- a/tests/ProfilingDataTest.php
+++ b/tests/ProfilingDataTest.php
@@ -9,8 +9,10 @@ class ProfilingDataTest extends TestCase
 {
     public function testExcludeAllEnv()
     {
+        $_ENV['TEST_EXCLUDE_ENV'] = 'TEST';
+
         $config = new Config([
-            'profiler.is-exclude-all-env' => true
+            'profiler.is-exclude-all-env' => true,
         ]);
         $profilingData = new ProfilingData($config);
 
@@ -19,6 +21,21 @@ class ProfilingDataTest extends TestCase
 
 
         $this->assertEmpty($result['meta']['env']);
+    }
+
+    public function testNotExcludeAllEnv()
+    {
+        $_ENV['TEST_EXCLUDE_ENV'] = 'TEST';
+
+        $config = new Config([
+            'profiler.is-exclude-all-env' => false,
+        ]);
+        $profilingData = new ProfilingData($config);
+
+        $profile = ['example' => 'data'];
+        $result = $profilingData->getProfilingData($profile);
+
+        $this->assertEquals('TEST', $result['meta']['env']['TEST_EXCLUDE_ENV']);
     }
 
 


### PR DESCRIPTION
This PR adds a new configuration option to exclude all `$_ENV` variables from the profiling data.

- New config: `'profiler.is-exclude-all-env' => false` (default: `false`)
- When set to `true`, all environment variables will be excluded from the result.
- Fixes #79

This helps prevent leaking a large number of secrets or sensitive information into the profiling output.