### PR TITLE
CI: Move from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   mongodb:
     name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -32,6 +32,8 @@ jobs:
     env:
       PHPUNIT_VERSION: "${{ matrix.phpunit }}"
       PHP_VERSION: "${{ matrix.php }}"
+      # https://getcomposer.org/doc/03-cli.md#environment-variables
+      COMPOSER_NO_SECURITY_BLOCKING: "1"
 
     services:
       mongodb:


### PR DESCRIPTION
The `ubuntu-20.04` will be fully retired by April 15, 2025:
- https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

Extracted from https://github.com/perftools/php-profiler/pull/87