### PR TITLE
Feature: Add ProfilingData object cache in Profiler

### DIFF
--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -49,6 +49,11 @@ final class Profiler
     private $requestContext;
 
     /**
+     * @var ProfilingData|null
+     */
+    private $profilingData;
+
+    /**
      * Simple state variable to hold the value of 'Is the profiler running or not?'
      *
      * @var bool
@@ -161,7 +166,7 @@ final class Profiler
             throw new ProfilerException('Unable to disable profiler: Request context is missing');
         }
 
-        $profile = new ProfilingData($this->config);
+        $profile = $this->getProfilingData();
 
         return $profile->getProfilingData($data, $context);
     }
@@ -327,5 +332,17 @@ final class Profiler
         }
 
         return $context;
+    }
+
+    /**
+     * @return ProfilingData
+     */
+    private function getProfilingData()
+    {
+        if ($this->profilingData === null) {
+            $this->profilingData = new ProfilingData($this->config);
+        }
+
+        return $this->profilingData;
     }
 }

--- a/tests/ProfilerTest.php
+++ b/tests/ProfilerTest.php
@@ -2,12 +2,28 @@
 
 namespace Xhgui\Profiler\Test;
 
+use ReflectionMethod;
+use Xhgui\Profiler\Config;
 use Xhgui\Profiler\Exception\ProfilerException;
 use Xhgui\Profiler\Profiler;
 use Xhgui\Profiler\Test\Resources\TestProfilerStub;
 
 class ProfilerTest extends TestCase
 {
+    public function testGetProfilingDataCachesInstance()
+    {
+        $profiler = new Profiler(new Config(array()));
+        $method = new ReflectionMethod($profiler, 'getProfilingData');
+        $method->setAccessible(true);
+
+        $first = $method->invoke($profiler);
+        $second = $method->invoke($profiler);
+
+        $this->assertInstanceOf('Xhgui\\Profiler\\ProfilingData', $first);
+        $this->assertSame($first, $second);
+        $this->assertSame($first, $this->getPrivateProperty($profiler, 'profilingData'));
+    }
+
     public function testDisableClearsStateWhenRequestContextIsMissing()
     {
         $profiler = new Profiler(array());


### PR DESCRIPTION
This is benefical for long running apps like Laravel Octane.