### PR TITLE
Fix: Resolve curl_close deprecation warning on php 8.5

### DIFF
--- a/src/Saver/UploadSaver.php
+++ b/src/Saver/UploadSaver.php
@@ -79,7 +79,10 @@ final class UploadSaver implements SaverInterface
             $error = curl_errno($ch) ? curl_error($ch) : '';
             throw new ProfilerException('Failed to submit data' . ($error ? ': ' . $error : ''));
         }
-        curl_close($ch);
+
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         $response = json_decode($result, true);
         if (!$response) {


### PR DESCRIPTION
## Pull request overview

This PR updates the `UploadSaver` cURL submission logic to avoid triggering the `curl_close()` deprecation warning introduced in PHP 8.5 (where `curl_close()` has been a no-op since PHP 8.0).

**Changes:**
- Make `curl_close($ch)` conditional on `PHP_VERSION_ID < 80000` to avoid PHP 8.5 deprecation warnings.

